### PR TITLE
feat!: Ignore `.keep` files

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -86,10 +86,17 @@ impl Iterator for Iterate {
     type Item = Result<std::path::PathBuf, std::io::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|e| {
+        while let Some(entry) = self.inner.next().map(|e| {
             e.map(walkdir::DirEntry::into_path)
                 .map_err(std::io::Error::from)
-        })
+        }) {
+            if entry.as_ref().ok().and_then(|e| e.file_name())
+                != Some(std::ffi::OsStr::new(".keep"))
+            {
+                return Some(entry);
+            }
+        }
+        None
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,13 +85,17 @@
 //!
 //! #### `*.in/`
 //!
-//! When present, this will automatically be picked as the CWD for the command
+//! When present, this will automatically be picked as the CWD for the command.
+//!
+//! `.keep` files will be ignored but their parent directories will be created.
 //!
 //! #### `*.out/`
 //!
 //! When present, each file in this directory will be compared to generated or modified files.
 //!
 //! See also "Eliding Content" for `.stdout`
+//!
+//! `.keep` files will be ignored.
 //!
 //! ### Workflow
 //!


### PR DESCRIPTION
These are a way to force a directory to be created that is empty.  We'll
create the directory but not copy the file over in sandboxes.  We will
also not verify these files.