### PR TITLE
Make `.trycmd` more cram like

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Here's a trivial example:
 
 ```rust,no_run
 #[test]
-fn ui() {
-    let t = trycmd::TestCases::new();
-    t.pass("tests/cmd/*.toml");
+fn cli_tests() {
+    trycmd::TestCases::new()
+        .case("tests/cmd/*.trycmd");
 }
 ```
 

--- a/src/cases.rs
+++ b/src/cases.rs
@@ -33,7 +33,7 @@ impl TestCases {
     pub fn fail(&self, glob: impl AsRef<std::path::Path>) -> &Self {
         self.runner
             .borrow_mut()
-            .case(glob.as_ref(), Some(crate::CommandStatus::Fail));
+            .case(glob.as_ref(), Some(crate::CommandStatus::Failed));
         self
     }
 
@@ -49,7 +49,7 @@ impl TestCases {
     pub fn skip(&self, glob: impl AsRef<std::path::Path>) -> &Self {
         self.runner
             .borrow_mut()
-            .case(glob.as_ref(), Some(crate::CommandStatus::Skip));
+            .case(glob.as_ref(), Some(crate::CommandStatus::Skipped));
         self
     }
 

--- a/src/cases.rs
+++ b/src/cases.rs
@@ -25,7 +25,7 @@ impl TestCases {
     pub fn pass(&self, glob: impl AsRef<std::path::Path>) -> &Self {
         self.runner
             .borrow_mut()
-            .case(glob.as_ref(), Some(crate::CommandStatus::Pass));
+            .case(glob.as_ref(), Some(crate::CommandStatus::Success));
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! - "`> `" line prefix appends to the prior command
 //! - "`? <status>`" line indicates the exit code (like `echo "? $?"`) and `<status>` can be
 //!   - An exit code
-//!   - `success`, `failed`, `interrupted`, `skipped`
+//!   - `success` *(default)*, `failed`, `interrupted`, `skipped`
 //!
 //! The command is then split with [shlex](https://crates.io/crates/shlex), allowing quoted content
 //! to allow spaces.  The first argument is the program to run which maps to `bin.name` in the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,15 @@
 //!
 //! #### `*.trycmd`
 //!
-//! A `trycmd` file is just a command with arguments, with the arguments split with [shlex](https://crates.io/crates/shlex).
+//! `.trycmd` files provide a more visually familiar way of specifying test cases.
 //!
-//! The command is interpreted as `bin.name` in a `toml` file.
+//! The basic syntax is:
+//! - "`$ `" line prefix starts a new command
+//! - "`> `" line prefix appends to the prior command
+//!
+//! The command is then split with [shlex](https://crates.io/crates/shlex), allowing quoted content
+//! to allow spaces.  The first argument is the program to run which maps to `bin.name` in the
+//! `.toml` file.
 //!
 //! #### `*.toml`
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@
 //! The basic syntax is:
 //! - "`$ `" line prefix starts a new command
 //! - "`> `" line prefix appends to the prior command
+//! - "`? <status>`" line indicates the exit code (like `echo "? $?"`) and `<status>` can be
+//!   - An exit code
+//!   - `success`, `failed`, `interrupted`, `skipped`
 //!
 //! The command is then split with [shlex](https://crates.io/crates/shlex), allowing quoted content
 //! to allow spaces.  The first argument is the program to run which maps to `bin.name` in the

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -246,7 +246,7 @@ impl Case {
     ) -> Result<Output, Output> {
         let status = output.spawn.exit.expect("bale out before now");
         match expected {
-            crate::CommandStatus::Pass => {
+            crate::CommandStatus::Success => {
                 if !status.success() {
                     output.spawn.status = SpawnStatus::Expected("success".into());
                 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -116,7 +116,7 @@ impl Case {
     pub(crate) fn run(&self, mode: &Mode, bins: &crate::BinRegistry) -> Result<Output, Output> {
         let mut output = Output::default();
 
-        if self.expected == Some(crate::CommandStatus::Skip) {
+        if self.expected == Some(crate::CommandStatus::Skipped) {
             assert_eq!(output.spawn.status, SpawnStatus::Skipped);
             return Ok(output);
         }
@@ -251,7 +251,7 @@ impl Case {
                     output.spawn.status = SpawnStatus::Expected("success".into());
                 }
             }
-            crate::CommandStatus::Fail => {
+            crate::CommandStatus::Failed => {
                 if status.success() || status.code().is_none() {
                     output.spawn.status = SpawnStatus::Expected("failure".into());
                 }
@@ -261,7 +261,7 @@ impl Case {
                     output.spawn.status = SpawnStatus::Expected("interrupted".into());
                 }
             }
-            crate::CommandStatus::Skip => unreachable!("handled earlier"),
+            crate::CommandStatus::Skipped => unreachable!("handled earlier"),
             crate::CommandStatus::Code(expected_code) => {
                 if Some(expected_code) != status.code() {
                     output.spawn.status = SpawnStatus::Expected(expected_code.to_string());

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -154,7 +154,7 @@ impl TryCmd {
 
     fn parse_trycmd(s: &str) -> Result<Self, String> {
         let mut cmdline = String::new();
-        let mut status = None;
+        let mut status = Some(CommandStatus::Success);
         for line in s.lines() {
             if let Some(raw) = line.strip_prefix("$ ") {
                 cmdline.clear();
@@ -433,6 +433,7 @@ mod test {
         let expected = TryCmd {
             bin: Some(Bin::Name("cmd".into())),
             args: Some(Args::default()),
+            status: Some(CommandStatus::Success),
             ..Default::default()
         };
         let actual = TryCmd::parse_trycmd("$ cmd").unwrap();
@@ -444,6 +445,7 @@ mod test {
         let expected = TryCmd {
             bin: Some(Bin::Name("cmd".into())),
             args: Some(Args::Split(vec!["arg1".into(), "arg with space".into()])),
+            status: Some(CommandStatus::Success),
             ..Default::default()
         };
         let actual = TryCmd::parse_trycmd("$ cmd arg1 'arg with space'").unwrap();
@@ -455,6 +457,7 @@ mod test {
         let expected = TryCmd {
             bin: Some(Bin::Name("cmd".into())),
             args: Some(Args::Split(vec!["arg1".into(), "arg with space".into()])),
+            status: Some(CommandStatus::Success),
             ..Default::default()
         };
         let actual = TryCmd::parse_trycmd("$ cmd arg1\n> 'arg with space'").unwrap();
@@ -474,6 +477,7 @@ mod test {
                 .collect(),
                 ..Default::default()
             },
+            status: Some(CommandStatus::Success),
             ..Default::default()
         };
         let actual = TryCmd::parse_trycmd("$ KEY1=VALUE1 KEY2='VALUE2 with space' cmd").unwrap();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -376,7 +376,7 @@ where
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum CommandStatus {
-    Pass,
+    Success,
     Fail,
     Interrupted,
     Skip,
@@ -385,7 +385,7 @@ pub enum CommandStatus {
 
 impl Default for CommandStatus {
     fn default() -> Self {
-        CommandStatus::Pass
+        CommandStatus::Success
     }
 }
 
@@ -498,10 +498,10 @@ mod test {
     #[test]
     fn parse_toml_status_success() {
         let expected = TryCmd {
-            status: Some(CommandStatus::Pass),
+            status: Some(CommandStatus::Success),
             ..Default::default()
         };
-        let actual = TryCmd::parse_toml("status = 'pass'").unwrap();
+        let actual = TryCmd::parse_toml("status = 'success'").unwrap();
         assert_eq!(expected, actual);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -377,9 +377,9 @@ where
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum CommandStatus {
     Success,
-    Fail,
+    Failed,
     Interrupted,
-    Skip,
+    Skipped,
     Code(i32),
 }
 

--- a/tests/cmd/basic.trycmd
+++ b/tests/cmd/basic.trycmd
@@ -1,1 +1,1 @@
-bin-fixture
+$ bin-fixture

--- a/tests/cmd/failure.toml
+++ b/tests/cmd/failure.toml
@@ -1,5 +1,5 @@
 bin.name = "bin-fixture"
-status = "fail"
+status = "failed"
 
 [env.add]
 exit = "1"

--- a/tests/cmd/schema.stdout
+++ b/tests/cmd/schema.stdout
@@ -193,7 +193,7 @@
         {
           "type": "string",
           "enum": [
-            "pass",
+            "success",
             "fail",
             "interrupted",
             "skip"

--- a/tests/cmd/schema.stdout
+++ b/tests/cmd/schema.stdout
@@ -194,9 +194,9 @@
           "type": "string",
           "enum": [
             "success",
-            "fail",
+            "failed",
             "interrupted",
-            "skip"
+            "skipped"
           ]
         },
         {

--- a/tests/cmd/schema.trycmd
+++ b/tests/cmd/schema.trycmd
@@ -1,1 +1,1 @@
-trycmd-schema
+$ trycmd-schema


### PR DESCRIPTION
This makes a `.trycmd` file look like:
```
$ ls
> -a
? success
```
with `>` being a line continuation and `?` being optional exit status.