### PR TITLE
fix: Overwrite support for *.trycmd files 

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -40,7 +40,7 @@ impl File {
         {
             if line_num == line_nums.start {
                 output_lines.push_str(text);
-                if !text.is_empty() && !text.ends_with("\n") {
+                if !text.is_empty() && !text.ends_with('\n') {
                     output_lines.push('\n');
                 }
             }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -24,6 +24,35 @@ impl File {
             .map_err(|e| format!("Failed to write {}: {}", path.display(), e))
     }
 
+    pub(crate) fn replace_lines(
+        &mut self,
+        line_nums: std::ops::Range<usize>,
+        text: &str,
+    ) -> Result<(), String> {
+        let mut output_lines = String::new();
+
+        let s = self
+            .as_str()
+            .ok_or("Binary file can't have lines replaced")?;
+        for (line_num, line) in crate::lines::LinesWithTerminator::new(s)
+            .enumerate()
+            .map(|(i, l)| (i + 1, l))
+        {
+            if line_num == line_nums.start {
+                output_lines.push_str(text);
+                if !text.is_empty() && !text.ends_with("\n") {
+                    output_lines.push('\n');
+                }
+            }
+            if !line_nums.contains(&line_num) {
+                output_lines.push_str(line);
+            }
+        }
+
+        *self = Self::Text(output_lines);
+        Ok(())
+    }
+
     pub(crate) fn map_text(self, op: impl FnOnce(&str) -> String) -> Self {
         match self {
             Self::Binary(data) => Self::Binary(data),
@@ -67,6 +96,13 @@ impl File {
                 Ok(data)
             }
             Self::Text(data) => Ok(data),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Binary(_) => None,
+            Self::Text(data) => Some(data.as_str()),
         }
     }
 
@@ -248,4 +284,69 @@ fn symlink_to_file(link: &std::path::Path, target: &std::path::Path) -> Result<(
 #[cfg(not(windows))]
 fn symlink_to_file(link: &std::path::Path, target: &std::path::Path) -> Result<(), std::io::Error> {
     std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn replace_lines_same_line_count() {
+        let input = "One\nTwo\nThree";
+        let line_nums = 2..3;
+        let replacement = "World\n";
+        let expected = File::Text("One\nWorld\nThree".into());
+
+        let mut actual = File::Text(input.into());
+        actual.replace_lines(line_nums, replacement).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn replace_lines_grow() {
+        let input = "One\nTwo\nThree";
+        let line_nums = 2..3;
+        let replacement = "World\nTrees\n";
+        let expected = File::Text("One\nWorld\nTrees\nThree".into());
+
+        let mut actual = File::Text(input.into());
+        actual.replace_lines(line_nums, replacement).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn replace_lines_shrink() {
+        let input = "One\nTwo\nThree";
+        let line_nums = 2..3;
+        let replacement = "";
+        let expected = File::Text("One\nThree".into());
+
+        let mut actual = File::Text(input.into());
+        actual.replace_lines(line_nums, replacement).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn replace_lines_no_trailing() {
+        let input = "One\nTwo\nThree";
+        let line_nums = 2..3;
+        let replacement = "World";
+        let expected = File::Text("One\nWorld\nThree".into());
+
+        let mut actual = File::Text(input.into());
+        actual.replace_lines(line_nums, replacement).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn replace_lines_empty_range() {
+        let input = "One\nTwo\nThree";
+        let line_nums = 2..2;
+        let replacement = "World\n";
+        let expected = File::Text("One\nWorld\nTwo\nThree".into());
+
+        let mut actual = File::Text(input.into());
+        actual.replace_lines(line_nums, replacement).unwrap();
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -376,18 +376,7 @@ impl Case {
         mode: &Mode,
     ) -> Result<Stream, Stream> {
         if let Mode::Dump(root) = mode {
-            let stdout_path = root.join(
-                self.path
-                    .with_extension(stream.stream.as_str())
-                    .file_name()
-                    .unwrap(),
-            );
-            stream.content.write_to(&stdout_path).map_err(|e| {
-                let mut stream = stream.clone();
-                stream.status = StreamStatus::Failure(e);
-                stream
-            })?;
-            return Ok(stream);
+            return self.dump_stream(root, stream);
         }
 
         if !binary {
@@ -429,6 +418,23 @@ impl Case {
         }
 
         Ok(stream)
+    }
+
+    fn dump_stream(&self, root: &std::path::Path, stream: Stream) -> Result<Stream, Stream> {
+        let stream_path = root.join(
+            self.path
+                .with_extension(stream.stream.as_str())
+                .file_name()
+                .unwrap(),
+        );
+        stream.content.write_to(&stream_path).map_err(|e| {
+            let mut stream = stream.clone();
+            if stream.is_ok() {
+                stream.status = StreamStatus::Failure(e);
+            }
+            stream
+        })?;
+        return Ok(stream);
     }
 
     fn validate_fs(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -82,6 +82,7 @@ impl TryCmd {
     }
 
     pub(crate) fn overwrite(
+        &self,
         path: &std::path::Path,
         id: Option<&str>,
         stdout: Option<&crate::File>,
@@ -90,15 +91,33 @@ impl TryCmd {
         if let Some(ext) = path.extension() {
             if ext == std::ffi::OsStr::new("toml") {
                 assert_eq!(id, None);
+
                 if let Some(stdout) = stdout {
                     let stdout_path = path.with_extension("stdout");
                     stdout.write_to(&stdout_path)?;
                 }
+
                 if let Some(stderr) = stderr {
                     let stderr_path = path.with_extension("stderr");
                     stderr.write_to(&stderr_path)?;
                 }
             } else if ext == std::ffi::OsStr::new("trycmd") || ext == std::ffi::OsStr::new("md") {
+                assert_eq!(stderr, Some(&crate::File::Text("".into())));
+                if let (Some(id), Some(stdout)) = (id, stdout) {
+                    let step = self
+                        .steps
+                        .iter()
+                        .find(|s| s.id.as_deref() == Some(id))
+                        .expect("id is valid");
+                    let line_nums = step
+                        .expected_stdout_source
+                        .clone()
+                        .expect("always present for .trycmd");
+                    let stdout = stdout.as_str().expect("already converted to Text");
+                    let mut raw = crate::File::read_from(path, false)?;
+                    raw.replace_lines(line_nums, stdout)?;
+                    raw.write_to(path)?;
+                }
             } else {
                 return Err(format!("Unsupported extension: {}", ext.to_string_lossy()));
             }
@@ -149,11 +168,13 @@ impl TryCmd {
                 let mut expected_status = Some(CommandStatus::Success);
                 let mut stdout = String::new();
                 let cmd_start;
+                let mut stdout_start;
 
                 if let Some((line_num, line)) = lines.pop_front() {
                     if let Some(raw) = line.strip_prefix("$ ") {
                         cmdline.extend(shlex::Shlex::new(raw.trim()));
                         cmd_start = line_num;
+                        stdout_start = line_num + 1;
                     } else {
                         return Err(format!("Expected `$` on line {}, got `{}`", line_num, line));
                     }
@@ -163,6 +184,7 @@ impl TryCmd {
                 while let Some((line_num, line)) = lines.pop_front() {
                     if let Some(raw) = line.strip_prefix("> ") {
                         cmdline.extend(shlex::Shlex::new(raw.trim()));
+                        stdout_start = line_num + 1;
                     } else {
                         lines.push_front((line_num, line));
                         break;
@@ -171,20 +193,25 @@ impl TryCmd {
                 if let Some((line_num, line)) = lines.pop_front() {
                     if let Some(raw) = line.strip_prefix("? ") {
                         expected_status = Some(raw.trim().parse::<CommandStatus>()?);
+                        stdout_start = line_num + 1;
                     } else {
                         lines.push_front((line_num, line));
                     }
                 }
+                let mut post_stdout_start = stdout_start;
                 let mut block_done = false;
                 while let Some((line_num, line)) = lines.pop_front() {
                     if line.starts_with("$ ") {
                         lines.push_front((line_num, line));
+                        post_stdout_start = line_num;
                         break;
                     } else if line.starts_with("```") {
                         block_done = true;
+                        post_stdout_start = line_num;
                         break;
                     } else {
                         stdout.push_str(line);
+                        post_stdout_start = line_num + 1;
                     }
                 }
 
@@ -206,10 +233,15 @@ impl TryCmd {
                     bin: Some(Bin::Name(bin)),
                     args: cmdline,
                     env,
-                    expected_status,
+                    stdin: None,
                     stderr_to_stdout: true,
+                    expected_status,
+                    expected_stdout_source: Some(stdout_start..post_stdout_start),
                     expected_stdout: Some(crate::File::Text(stdout)),
-                    ..Default::default()
+                    expected_stderr_source: None,
+                    expected_stderr: None,
+                    binary: false,
+                    timeout: None,
                 };
                 steps.push(step);
                 if block_done {
@@ -254,7 +286,9 @@ impl From<OneShot> for TryCmd {
                 stdin: None,
                 stderr_to_stdout,
                 expected_status: status,
+                expected_stdout_source: None,
                 expected_stdout: None,
+                expected_stderr_source: None,
                 expected_stderr: None,
                 binary,
                 timeout,
@@ -273,7 +307,9 @@ pub(crate) struct Step {
     pub(crate) stdin: Option<crate::File>,
     pub(crate) stderr_to_stdout: bool,
     pub(crate) expected_status: Option<CommandStatus>,
+    pub(crate) expected_stdout_source: Option<std::ops::Range<usize>>,
     pub(crate) expected_stdout: Option<crate::File>,
+    pub(crate) expected_stderr_source: Option<std::ops::Range<usize>>,
     pub(crate) expected_stderr: Option<crate::File>,
     pub(crate) binary: bool,
     pub(crate) timeout: Option<std::time::Duration>,
@@ -634,6 +670,7 @@ mod test {
                 bin: Some(Bin::Name("cmd".into())),
                 expected_status: Some(CommandStatus::Success),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(4..4),
                 expected_stdout: Some(crate::File::Text("".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -660,6 +697,7 @@ $ cmd
                 args: vec!["arg1".into(), "arg with space".into()],
                 expected_status: Some(CommandStatus::Success),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(4..4),
                 expected_stdout: Some(crate::File::Text("".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -686,6 +724,7 @@ $ cmd arg1 'arg with space'
                 args: vec!["arg1".into(), "arg with space".into()],
                 expected_status: Some(CommandStatus::Success),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(5..5),
                 expected_stdout: Some(crate::File::Text("".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -720,6 +759,7 @@ $ cmd arg1
                 },
                 expected_status: Some(CommandStatus::Success),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(4..4),
                 expected_stdout: Some(crate::File::Text("".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -745,6 +785,7 @@ $ KEY1=VALUE1 KEY2='VALUE2 with space' cmd
                 bin: Some(Bin::Name("cmd".into())),
                 expected_status: Some(CommandStatus::Skipped),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(5..5),
                 expected_stdout: Some(crate::File::Text("".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -771,6 +812,7 @@ $ cmd
                 bin: Some(Bin::Name("cmd".into())),
                 expected_status: Some(CommandStatus::Code(-1)),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(5..5),
                 expected_stdout: Some(crate::File::Text("".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -797,6 +839,7 @@ $ cmd
                 bin: Some(Bin::Name("cmd".into())),
                 expected_status: Some(CommandStatus::Success),
                 stderr_to_stdout: true,
+                expected_stdout_source: Some(4..5),
                 expected_stdout: Some(crate::File::Text("Hello World\n".into())),
                 expected_stderr: None,
                 ..Default::default()
@@ -823,6 +866,7 @@ Hello World
                     bin: Some(Bin::Name("cmd1".into())),
                     expected_status: Some(CommandStatus::Code(1)),
                     stderr_to_stdout: true,
+                    expected_stdout_source: Some(5..5),
                     expected_stdout: Some(crate::File::Text("".into())),
                     expected_stderr: None,
                     ..Default::default()
@@ -832,6 +876,7 @@ Hello World
                     bin: Some(Bin::Name("cmd2".into())),
                     expected_status: Some(CommandStatus::Success),
                     stderr_to_stdout: true,
+                    expected_stdout_source: Some(6..6),
                     expected_stdout: Some(crate::File::Text("".into())),
                     expected_stderr: None,
                     ..Default::default()
@@ -861,6 +906,7 @@ $ cmd2
                     bin: Some(Bin::Name("bare-cmd".into())),
                     expected_status: Some(CommandStatus::Code(1)),
                     stderr_to_stdout: true,
+                    expected_stdout_source: Some(5..5),
                     expected_stdout: Some(crate::File::Text("".into())),
                     expected_stderr: None,
                     ..Default::default()
@@ -870,6 +916,7 @@ $ cmd2
                     bin: Some(Bin::Name("trycmd-cmd".into())),
                     expected_status: Some(CommandStatus::Code(1)),
                     stderr_to_stdout: true,
+                    expected_stdout_source: Some(10..10),
                     expected_stdout: Some(crate::File::Text("".into())),
                     expected_stderr: None,
                     ..Default::default()
@@ -879,6 +926,7 @@ $ cmd2
                     bin: Some(Bin::Name("sh-cmd".into())),
                     expected_status: Some(CommandStatus::Code(1)),
                     stderr_to_stdout: true,
+                    expected_stdout_source: Some(15..15),
                     expected_stdout: Some(crate::File::Text("".into())),
                     expected_stderr: None,
                     ..Default::default()
@@ -888,6 +936,7 @@ $ cmd2
                     bin: Some(Bin::Name("bash-cmd".into())),
                     expected_status: Some(CommandStatus::Code(1)),
                     stderr_to_stdout: true,
+                    expected_stdout_source: Some(20..20),
                     expected_stdout: Some(crate::File::Text("".into())),
                     expected_stderr: None,
                     ..Default::default()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -81,6 +81,34 @@ impl TryCmd {
         Ok(sequence)
     }
 
+    pub(crate) fn overwrite(
+        path: &std::path::Path,
+        id: Option<&str>,
+        stdout: Option<&crate::File>,
+        stderr: Option<&crate::File>,
+    ) -> Result<(), String> {
+        if let Some(ext) = path.extension() {
+            if ext == std::ffi::OsStr::new("toml") {
+                assert_eq!(id, None);
+                if let Some(stdout) = stdout {
+                    let stdout_path = path.with_extension("stdout");
+                    stdout.write_to(&stdout_path)?;
+                }
+                if let Some(stderr) = stderr {
+                    let stderr_path = path.with_extension("stderr");
+                    stderr.write_to(&stderr_path)?;
+                }
+            } else if ext == std::ffi::OsStr::new("trycmd") || ext == std::ffi::OsStr::new("md") {
+            } else {
+                return Err(format!("Unsupported extension: {}", ext.to_string_lossy()));
+            }
+        } else {
+            return Err("No extension".into());
+        }
+
+        Ok(())
+    }
+
     fn parse_trycmd(s: &str) -> Result<Self, String> {
         let mut steps = Vec::new();
 


### PR DESCRIPTION
The downside is this makes it so overwrite runs are considered failures,
even obscuring the real failure or making the user think it didn't work.

Fixes #23