### PR TITLE
fix: Don't conflate spawn status with status

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -61,7 +61,7 @@ impl Runner {
                                         "{} {} ... {}",
                                         palette.hint.paint("Testing"),
                                         status.name(),
-                                        status.spawn.status.summary()
+                                        palette.error.paint("failed"),
                                     );
                                     // Assuming `status` will print the newline
                                     let _ = write!(stderr, "{}", &status);


### PR DESCRIPTION
If stdout doesn't match, we were considering this ok when it should be a
failure.

This probably broke in e4365dbf when we consolidated the message
formatting.