### PR TITLE
feat: Provide inline eliding of text

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@
 //! To elide a section of content:
 //! - `...` as its own line: match all lines until the next one.  This is equivalent of
 //!   `\n(([^\n]*\n)*?`.
+//! - `...` as part of a line: match any characters.  This is equivalent of `[^\n]*?`.
 //!
 //! We will preserve these with `TRYCMD=dump` and will make a best-effort at preserving them with
 //! `TRYCMD=overwrite`.


### PR DESCRIPTION
This will be useful for clap for eliding the `.exe` for windows.

I feel so dirty writing this by hand.  Who knows what corner cases are
lurkling :/.  I'm just concerned about keeping this "light".  We'll see
how this goes.

I'm also mixed about whether line `...` should look for a literal line
or also lines with inline `...`.  Going with the simple option for now.

Fixes #5