### PR TITLE
fix: Ignore unknown bins

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -33,28 +33,26 @@ impl BinRegistry {
                 Ok(bin)
             }
             crate::schema::Bin::Name(name) => {
-                let bin = self
-                    .resolve_name(&name)
-                    .ok_or_else(|| format!("Unknown bin.name = {}", name))?;
+                let bin = self.resolve_name(&name);
                 Ok(bin)
             }
             crate::schema::Bin::Error(err) => Err(err),
         }
     }
 
-    pub(crate) fn resolve_name(&self, name: &str) -> Option<crate::schema::Bin> {
+    pub(crate) fn resolve_name(&self, name: &str) -> crate::schema::Bin {
         if let Some(path) = self.bins.get(name) {
-            return Some(path.clone());
+            return path.clone();
         }
 
         if self.fallback {
             let path = crate::cargo::cargo_bin(name);
             if path.exists() {
-                return Some(crate::schema::Bin::Path(path));
+                return crate::schema::Bin::Path(path);
             }
         }
 
-        None
+        crate::schema::Bin::Name(name.to_owned())
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -48,7 +48,10 @@ impl BinRegistry {
         }
 
         if self.fallback {
-            return Some(crate::schema::Bin::Path(crate::cargo::cargo_bin(name)));
+            let path = crate::cargo::cargo_bin(name);
+            if path.exists() {
+                return Some(crate::schema::Bin::Path(path));
+            }
         }
 
         None

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -322,6 +322,20 @@ impl Case {
             return Ok(output);
         }
 
+        #[allow(unused_variables)]
+        match &step.bin {
+            Some(crate::schema::Bin::Path(_)) => {}
+            Some(crate::schema::Bin::Name(name)) => {
+                // Unhandled by resolve
+                debug!("bin={:?} not found", name);
+                assert_eq!(output.spawn.status, SpawnStatus::Skipped);
+                return Ok(output);
+            }
+            Some(crate::schema::Bin::Error(_)) => {}
+            // Unlike `Name`, this always represents a bug
+            None => {}
+        }
+
         let cmd_output = step.to_output(cwd).map_err(|e| output.clone().error(e))?;
         let output = output.output(cmd_output);
 

--- a/tests/cmd/unresolved.trycmd
+++ b/tests/cmd/unresolved.trycmd
@@ -1,0 +1,4 @@
+Gracefully handle a non-existent name:
+```
+$ non-existent-name
+```


### PR DESCRIPTION
This is helpful for when working with bins behind feature flags (like
examples).