### PR TITLE
fix: Run all steps when no dependency

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -211,7 +211,7 @@ impl Case {
             }
 
             let step_status = self.run_step(step, cwd.as_deref(), bins, &substitutions);
-            if step_status.is_err() && *mode == Mode::Fail {
+            if fs_context.is_sandbox() && step_status.is_err() && *mode == Mode::Fail {
                 prior_step_failed = true;
             }
             outputs.push(step_status);


### PR DESCRIPTION
When a `.trycmd` file has multiple steps, we skip all steps after a
failure, assuming there is a dependency between them.  This is only
strictly true when the file system is being touched.  Otherwise, the
relationship is more nebulous and depends on how the person setup the
tests.