### PR TITLE
Bump `escargot` version to `0.5.7`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ shlex = "1.1.0"
 humantime = "2"
 humantime-serde = "1"
 toml_edit = { version = "0.10", features = ["serde"] }
-escargot = { version = "0.5.6", optional = true }
+escargot = { version = "0.5.7", optional = true }
 
 normalize-line-endings = "0.3.0"
 os_pipe = "1.0"


### PR DESCRIPTION
Part of https://github.com/clap-rs/clap/pull/3172