### PR TITLE
fix(md)!: Use `console` for infostring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! ## Workflow
 //!
 //! To generate snapshots, run
-//! ```bash
+//! ```console
 //! $ TRYCMD=dump cargo test --test cli_tests
 //! ```
 //! This will write all of the `.stdout` and `.stderr` files in a `dump/` directory.
@@ -49,13 +49,13 @@
 //! You can then copy over to `tests/cmd` the cases you want to test
 //!
 //! To update snapshots, run
-//! ```bash
+//! ```console
 //! $ TRYCMD=overwrite cargo test --test cli_tests
 //! ```
 //! This will overwrite any existing `.stdout` and `.stderr` file in `tests/cmd`
 //!
 //! To filter the tests to those with `name1`, `name2`, etc in their file names, you can run:
-//! ```bash
+//! ```console
 //! cargo test --test cli_tests -- cli_tests trycmd=name1 trycmd=name2...
 //! ```
 //!
@@ -85,7 +85,7 @@
 //! The syntax is:
 //! - Test cases live inside of ` ``` ` fenced code blocks
 //!   - Everything out of them is ignored
-//!   - Blocks with info strings with an unsupported language (not `trycmd`, `bash`, `sh`) or the
+//!   - Blocks with info strings with an unsupported language (not `trycmd`, `console`) or the
 //!     `ignore` attribute are ignored
 //! - "`$ `" line prefix starts a new command
 //! - "`> `" line prefix appends to the prior command

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -148,7 +148,7 @@ impl TryCmd {
                         let mut info = raw.split(',');
                         let lang = info.next().unwrap();
                         match lang {
-                            "trycmd" | "bash" | "sh" => {
+                            "trycmd" | "console" => {
                                 if info.any(|i| i == "ignore") {
                                     debug!("ignore from infostring: {:?}", info);
                                 } else {
@@ -931,18 +931,8 @@ $ cmd2
                     ..Default::default()
                 },
                 Step {
-                    id: Some("13".into()),
-                    bin: Some(Bin::Name("sh-cmd".into())),
-                    expected_status: Some(CommandStatus::Code(1)),
-                    stderr_to_stdout: true,
-                    expected_stdout_source: Some(15..15),
-                    expected_stdout: Some(crate::File::Text("".into())),
-                    expected_stderr: None,
-                    ..Default::default()
-                },
-                Step {
                     id: Some("18".into()),
-                    bin: Some(Bin::Name("bash-cmd".into())),
+                    bin: Some(Bin::Name("console-cmd".into())),
                     expected_status: Some(CommandStatus::Code(1)),
                     stderr_to_stdout: true,
                     expected_stdout_source: Some(20..20),
@@ -970,8 +960,8 @@ $ sh-cmd
 ? 1
 ```
 
-```bash
-$ bash-cmd
+```console
+$ console-cmd
 ? 1
 ```
 


### PR DESCRIPTION
BREAKING CHANGE: `bash` and `sh` info strings for code blocks are now
ignored, switch to `console` or `trycmd`.