### PR TITLE
feat(md)!: Allow verifying without trailing newline

### DIFF
--- a/tests/cmd/basic.trycmd
+++ b/tests/cmd/basic.trycmd
@@ -1,3 +1,4 @@
 ```
 $ bin-fixture
+
 ```

--- a/tests/cmd/multistep.trycmd
+++ b/tests/cmd/multistep.trycmd
@@ -3,11 +3,14 @@ Basic test:
 $ stdout='Hello' stderr='Goodbye' bin-fixture
 Hello
 Goodbye
+
 ```
 
 Mess with the sandbox:
 ```
 $ write='file.txt = Goodbye' bin-fixture
+
 $ cat='file.txt' bin-fixture
 Goodbye
+
 ```

--- a/tests/cmd/stdout.trycmd
+++ b/tests/cmd/stdout.trycmd
@@ -2,4 +2,5 @@
 $ stdout='Hello' stderr='Goodbye' bin-fixture
 Hello
 Goodbye
+
 ```

--- a/tests/cmd/unresolved.trycmd
+++ b/tests/cmd/unresolved.trycmd
@@ -1,4 +1,5 @@
 Gracefully handle a non-existent name:
 ```
 $ non-existent-name
+
 ```

--- a/tests/cmd/vars.trycmd
+++ b/tests/cmd/vars.trycmd
@@ -2,4 +2,5 @@
 $ stdout='example' stderr='Goodbye' bin-fixture
 [EXAMPLE]
 Goodbye
+
 ```


### PR DESCRIPTION
Because of how we parsed the file, the stdout for an `md` code block
always had a newline at the end.  This prevents verifying applications
that do not output a trailing newline (usually applications should).

By stripping and re-adding the newline, we also provide more visual
separarion between the commands, making the output eaiser to read.

BREAKING CHANGE: All `md` command outputs need an extra newline