### PR TITLE
feat!: Normalize path separators

### DIFF
--- a/src/elide.rs
+++ b/src/elide.rs
@@ -35,7 +35,10 @@ impl Substitutions {
         if value.is_empty() {
             self.unused.insert(key);
         } else {
-            self.vars.insert(key, value);
+            self.vars.insert(
+                key,
+                crate::filesystem::normalize_text(value.as_ref()).into(),
+            );
         }
         Ok(())
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -13,7 +13,7 @@ impl File {
         } else {
             let data = std::fs::read_to_string(&path)
                 .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-            let data = normalize_line_endings::normalized(data.chars()).collect();
+            let data = normalize_text(&data);
             Self::Text(data)
         };
         Ok(data)
@@ -64,7 +64,7 @@ impl File {
         match self {
             Self::Binary(data) => {
                 let data = String::from_utf8(data.clone()).map_err(|e| e.utf8_error())?;
-                let data = normalize_line_endings::normalized(data.chars()).collect();
+                let data = normalize_text(&data);
                 *self = Self::Text(data);
                 Ok(())
             }
@@ -76,7 +76,7 @@ impl File {
         match self {
             Self::Binary(data) => match String::from_utf8(data) {
                 Ok(data) => {
-                    let data = normalize_line_endings::normalized(data.chars()).collect();
+                    let data = normalize_text(&data);
                     Self::Text(data)
                 }
                 Err(err) => {
@@ -92,7 +92,7 @@ impl File {
         match self {
             Self::Binary(data) => {
                 let data = String::from_utf8(data).map_err(|e| e.utf8_error())?;
-                let data = normalize_line_endings::normalized(data.chars()).collect();
+                let data = normalize_text(&data);
                 Ok(data)
             }
             Self::Text(data) => Ok(data),
@@ -112,6 +112,10 @@ impl File {
             Self::Text(data) => data.as_bytes(),
         }
     }
+}
+
+fn normalize_text(data: &str) -> String {
+    normalize_line_endings::normalized(data.chars()).collect()
 }
 
 impl std::fmt::Display for File {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -114,8 +114,11 @@ impl File {
     }
 }
 
-fn normalize_text(data: &str) -> String {
-    normalize_line_endings::normalized(data.chars()).collect()
+pub(crate) fn normalize_text(data: &str) -> String {
+    normalize_line_endings::normalized(data.chars())
+        // Also help out with Windows paths
+        .map(|c| if c == '\\' { '/' } else { c })
+        .collect()
 }
 
 impl std::fmt::Display for File {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,13 +126,13 @@
 //!
 //! Data to pass to `stdin`.
 //! - If not present, nothing will be written to `stdin`
-//! - If `binary = false` in `*.toml` (the default), newlines will be normalized.
+//! - If `binary = false` in `*.toml` (the default), newlines and path separators will be normalized.
 //!
 //! #### `*.stdout` and `*.stderr`
 //!
 //! Expected results for `stdout` or `stderr`.
 //! - If not present, we'll not verify the output
-//! - If `binary = false` in `*.toml` (the default), newlines will be normalized before comparing
+//! - If `binary = false` in `*.toml` (the default), newlines and path separators will be normalized before comparing
 //!
 //! **Eliding Content**
 //!


### PR DESCRIPTION
Cargo does this.  I've been trying to avoid it but its inevitable
because there is the chance we hide something important.