### PR TITLE
feat: Allow stdin/stdout/stderr in toml 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,10 @@ pre-release-replacements = [
 default = ["color-auto", "filesystem", "diff"]
 color = ["yansi", "concolor/std"]
 color-auto = ["color", "concolor/auto"]
-schema = ["schemars", "serde_json"]
 diff = ["difflib"]
 filesystem = ["tempfile", "walkdir", "dunce"]
+
+schema = ["schemars", "serde_json"]
 examples = ["escargot"]
 debug = ["backtrace"]
 

--- a/tests/cmd/schema.stdout
+++ b/tests/cmd/schema.stdout
@@ -34,6 +34,27 @@
         }
       ]
     },
+    "stdin": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "stdout": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "stderr": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "stderr-to-stdout": {
       "default": false,
       "type": "boolean"

--- a/tests/cmd/stderr_toml.toml
+++ b/tests/cmd/stderr_toml.toml
@@ -1,0 +1,12 @@
+bin.name = "bin-fixture"
+stderr = """
+Hello
+World!
+
+"""
+
+[env.add]
+stderr = """
+Hello
+World!
+"""


### PR DESCRIPTION
This doesn't work with binary data but should be convinient for text
which is the majority of cases.  This should reduce the proliferation of
files in cases like killercup/cargo-edit#566.