### PR TITLE
fix: Auto-detect binary files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default = ["color-auto", "filesystem", "diff"]
 color = ["yansi", "concolor/std"]
 color-auto = ["color", "concolor/auto"]
 diff = ["difflib"]
-filesystem = ["tempfile", "walkdir", "dunce"]
+filesystem = ["tempfile", "walkdir", "dunce", "content_inspector"]
 
 schema = ["schemars", "serde_json"]
 examples = ["escargot"]
@@ -71,6 +71,7 @@ tempfile = { version = "3.0", optional = true }
 walkdir = { version = "2.3.2", optional = true }
 backtrace = { version = "0.3", optional = true }
 dunce = { version = "1.0", optional = true }
+content_inspector = { version = "0.2.4", optional = true }
 
 schemars = { version = "0.8.3", features = ["preserve_order"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -616,10 +616,10 @@ impl Case {
                 }
             }
             FileType::File => {
-                let expected_content = crate::File::read_from(&expected_path, true)
+                let expected_content = crate::File::read_from(&expected_path, None)
                     .map_err(FileStatus::Failure)?
                     .try_utf8();
-                let mut actual_content = crate::File::read_from(&actual_path, true)
+                let mut actual_content = crate::File::read_from(&actual_path, None)
                     .map_err(FileStatus::Failure)?
                     .try_utf8();
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -25,7 +25,7 @@ impl TryCmd {
                 if sequence.steps[0].stdin.is_none() {
                     let stdin_path = path.with_extension("stdin");
                     let stdin = if stdin_path.exists() {
-                        Some(crate::File::read_from(&stdin_path, is_binary)?)
+                        Some(crate::File::read_from(&stdin_path, Some(is_binary))?)
                     } else {
                         None
                     };
@@ -35,7 +35,7 @@ impl TryCmd {
                 if sequence.steps[0].expected_stdout.is_none() {
                     let stdout_path = path.with_extension("stdout");
                     let stdout = if stdout_path.exists() {
-                        Some(crate::File::read_from(&stdout_path, is_binary)?)
+                        Some(crate::File::read_from(&stdout_path, Some(is_binary))?)
                     } else {
                         None
                     };
@@ -45,7 +45,7 @@ impl TryCmd {
                 if sequence.steps[0].expected_stderr.is_none() {
                     let stderr_path = path.with_extension("stderr");
                     let stderr = if stderr_path.exists() {
-                        Some(crate::File::read_from(&stderr_path, is_binary)?)
+                        Some(crate::File::read_from(&stderr_path, Some(is_binary))?)
                     } else {
                         None
                     };
@@ -54,7 +54,9 @@ impl TryCmd {
 
                 sequence
             } else if ext == std::ffi::OsStr::new("trycmd") || ext == std::ffi::OsStr::new("md") {
-                let raw = crate::File::read_from(path, false)?.into_utf8().unwrap();
+                let raw = crate::File::read_from(path, Some(false))?
+                    .into_utf8()
+                    .unwrap();
                 Self::parse_trycmd(&raw)?
             } else {
                 return Err(format!("Unsupported extension: {}", ext.to_string_lossy()).into());
@@ -138,7 +140,7 @@ impl TryCmd {
                         .to_owned();
                     // Add back trailing newline removed when parsing
                     stdout.push('\n');
-                    let mut raw = crate::File::read_from(path, false)?;
+                    let mut raw = crate::File::read_from(path, Some(false))?;
                     raw.replace_lines(line_nums, &stdout)?;
                     raw.write_to(path)?;
                 }


### PR DESCRIPTION
`binary` only impacts stdin/stdout/stderr.  File systems tend to be too
diverse to be controlled by a single flag.  Before we erred on the side
of always assuming text.  Now we will assume a file is text only if it
doesn't look like its binary and it is valid UTF-8

Fixes #61