### PR TITLE
fix: Be consistent in parameter order

### DIFF
--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -559,11 +559,10 @@ impl OutputAssert {
     #[track_caller]
     fn stdout_eq_inner(self, expected: crate::Data) -> Self {
         let actual = crate::Data::from(self.output.stdout.as_slice());
-        let (actual, pattern) = self.config.normalize_eq(actual, Ok(expected));
-        if let Err(desc) = pattern.and_then(|p| {
-            self.config
-                .try_verify(&actual, &p, Some(&"stdout"), Some(&"stdout"))
-        }) {
+        let (pattern, actual) = self.config.normalize_eq(Ok(expected), actual);
+        if let Err(desc) =
+            pattern.and_then(|p| self.config.try_verify(&p, &actual, None, Some(&"stdout")))
+        {
             use std::fmt::Write;
             let mut buf = String::new();
             write!(&mut buf, "{}", desc).unwrap();
@@ -597,13 +596,13 @@ impl OutputAssert {
     fn stdout_eq_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stdout.as_slice());
         let expected = crate::Data::read_from(expected_path, self.config.binary);
-        let (actual, pattern) = self.config.normalize_eq(actual, expected);
+        let (pattern, actual) = self.config.normalize_eq(expected, actual);
         self.config.do_action(
-            actual,
             pattern,
-            expected_path,
-            Some(&"stdout"),
+            actual,
             Some(&expected_path.display()),
+            Some(&"stdout"),
+            expected_path,
         );
 
         self
@@ -630,11 +629,10 @@ impl OutputAssert {
     #[track_caller]
     fn stdout_matches_inner(self, expected: crate::Data) -> Self {
         let actual = crate::Data::from(self.output.stdout.as_slice());
-        let (actual, pattern) = self.config.normalize_match(actual, Ok(expected));
-        if let Err(desc) = pattern.and_then(|p| {
-            self.config
-                .try_verify(&actual, &p, Some(&"stdout"), Some(&"stdout"))
-        }) {
+        let (pattern, actual) = self.config.normalize_match(Ok(expected), actual);
+        if let Err(desc) =
+            pattern.and_then(|p| self.config.try_verify(&p, &actual, None, Some(&"stdout")))
+        {
             use std::fmt::Write;
             let mut buf = String::new();
             write!(&mut buf, "{}", desc).unwrap();
@@ -668,13 +666,13 @@ impl OutputAssert {
     fn stdout_matches_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stdout.as_slice());
         let expected = crate::Data::read_from(expected_path, self.config.binary);
-        let (actual, pattern) = self.config.normalize_match(actual, expected);
+        let (pattern, actual) = self.config.normalize_match(expected, actual);
         self.config.do_action(
-            actual,
             pattern,
-            expected_path,
-            Some(&"stdout"),
+            actual,
             Some(&expected_path.display()),
+            Some(&"stdout"),
+            expected_path,
         );
 
         self
@@ -701,11 +699,10 @@ impl OutputAssert {
     #[track_caller]
     fn stderr_eq_inner(self, expected: crate::Data) -> Self {
         let actual = crate::Data::from(self.output.stderr.as_slice());
-        let (actual, pattern) = self.config.normalize_eq(actual, Ok(expected));
-        if let Err(desc) = pattern.and_then(|p| {
-            self.config
-                .try_verify(&actual, &p, Some(&"stderr"), Some(&"stderr"))
-        }) {
+        let (pattern, actual) = self.config.normalize_eq(Ok(expected), actual);
+        if let Err(desc) =
+            pattern.and_then(|p| self.config.try_verify(&p, &actual, None, Some(&"stderr")))
+        {
             use std::fmt::Write;
             let mut buf = String::new();
             write!(&mut buf, "{}", desc).unwrap();
@@ -739,13 +736,13 @@ impl OutputAssert {
     fn stderr_eq_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stderr.as_slice());
         let expected = crate::Data::read_from(expected_path, self.config.binary);
-        let (actual, pattern) = self.config.normalize_eq(actual, expected);
+        let (pattern, actual) = self.config.normalize_eq(expected, actual);
         self.config.do_action(
-            actual,
             pattern,
-            expected_path,
-            Some(&"stderr"),
+            actual,
             Some(&expected_path.display()),
+            Some(&"stderr"),
+            expected_path,
         );
 
         self
@@ -772,11 +769,10 @@ impl OutputAssert {
     #[track_caller]
     fn stderr_matches_inner(self, expected: crate::Data) -> Self {
         let actual = crate::Data::from(self.output.stderr.as_slice());
-        let (actual, pattern) = self.config.normalize_match(actual, Ok(expected));
-        if let Err(desc) = pattern.and_then(|p| {
-            self.config
-                .try_verify(&actual, &p, Some(&"stderr"), Some(&"stderr"))
-        }) {
+        let (pattern, actual) = self.config.normalize_match(Ok(expected), actual);
+        if let Err(desc) =
+            pattern.and_then(|p| self.config.try_verify(&p, &actual, None, Some(&"stderr")))
+        {
             use std::fmt::Write;
             let mut buf = String::new();
             write!(&mut buf, "{}", desc).unwrap();
@@ -810,13 +806,13 @@ impl OutputAssert {
     fn stderr_matches_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stderr.as_slice());
         let expected = crate::Data::read_from(expected_path, self.config.binary);
-        let (actual, pattern) = self.config.normalize_match(actual, expected);
+        let (pattern, actual) = self.config.normalize_match(expected, actual);
         self.config.do_action(
-            actual,
             pattern,
-            expected_path,
-            Some(&"stderr"),
+            actual,
             Some(&expected_path.display()),
+            Some(&"stderr"),
+            expected_path,
         );
 
         self

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -47,15 +47,16 @@
 //!
 //! [`assert_matches`]
 //! ```rust
-//! snapbox::assert_matches("Hello many people!", "Hello [..] people!");
+//! snapbox::assert_matches("Hello [..] people!", "Hello many people!");
 //! ```
 //!
 //! [`Assert`]
 //! ```rust,no_run
 //! let actual = "...";
+//! let expected_path = "tests/fixtures/help_output_is_clean.txt";
 //! snapbox::Assert::new()
 //!     .action_env("SNAPSHOT_ACTION")
-//!     .matches_path(actual, "tests/fixtures/help_output_is_clean.txt");
+//!     .matches_path(expected_path, actual);
 //! ```
 //!
 //! [`harness::Harness`]
@@ -84,9 +85,9 @@
 //!     let raw = std::fs::read_to_string(input_path)?;
 //!     let num = raw.parse::<usize>()?;
 //!
-//!     let expected = num + 10;
+//!     let actual = num + 10;
 //!
-//!     Ok(expected)
+//!     Ok(actual)
 //! }
 //! ```
 //!
@@ -123,11 +124,12 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 ///
 /// ```rust
 /// let output = "something";
-/// snapbox::assert_eq(output, "something");
+/// let expected = "something";
+/// snapbox::assert_matches(expected, output);
 /// ```
 #[track_caller]
-pub fn assert_eq(actual: impl Into<crate::Data>, expected: impl Into<crate::Data>) {
-    Assert::new().eq(actual, expected);
+pub fn assert_eq(expected: impl Into<crate::Data>, actual: impl Into<crate::Data>) {
+    Assert::new().eq(expected, actual);
 }
 
 /// Check if a value matches a pattern
@@ -143,11 +145,12 @@ pub fn assert_eq(actual: impl Into<crate::Data>, expected: impl Into<crate::Data
 ///
 /// ```rust
 /// let output = "something";
-/// snapbox::assert_matches(output, "so[..]g");
+/// let expected = "so[..]g";
+/// snapbox::assert_matches(expected, output);
 /// ```
 #[track_caller]
-pub fn assert_matches(actual: impl Into<crate::Data>, pattern: impl Into<crate::Data>) {
-    Assert::new().matches(actual, pattern);
+pub fn assert_matches(pattern: impl Into<crate::Data>, actual: impl Into<crate::Data>) {
+    Assert::new().matches(pattern, actual);
 }
 
 /// Check if a value matches the content of a file
@@ -156,11 +159,12 @@ pub fn assert_matches(actual: impl Into<crate::Data>, pattern: impl Into<crate::
 ///
 /// ```rust,no_run
 /// let output = "something";
-/// snapbox::assert_eq_path(output, "tests/snapshots/output.txt");
+/// let expected_path = "tests/snapshots/output.txt";
+/// snapbox::assert_eq_path(expected_path, output);
 /// ```
 #[track_caller]
-pub fn assert_eq_path(actual: impl Into<crate::Data>, expected_path: impl AsRef<std::path::Path>) {
-    Assert::new().eq_path(actual, expected_path);
+pub fn assert_eq_path(expected_path: impl AsRef<std::path::Path>, actual: impl Into<crate::Data>) {
+    Assert::new().eq_path(expected_path, actual);
 }
 
 /// Check if a value matches the pattern in a file
@@ -176,12 +180,13 @@ pub fn assert_eq_path(actual: impl Into<crate::Data>, expected_path: impl AsRef<
 ///
 /// ```rust,no_run
 /// let output = "something";
-/// snapbox::assert_matches_path(output, "tests/snapshots/output.txt");
+/// let expected_path = "tests/snapshots/output.txt";
+/// snapbox::assert_matches_path(expected_path, output);
 /// ```
 #[track_caller]
 pub fn assert_matches_path(
-    actual: impl Into<crate::Data>,
     pattern_path: impl AsRef<std::path::Path>,
+    actual: impl Into<crate::Data>,
 ) {
-    Assert::new().matches_path(actual, pattern_path);
+    Assert::new().matches_path(pattern_path, actual);
 }

--- a/crates/snapbox/src/path.rs
+++ b/crates/snapbox/src/path.rs
@@ -131,18 +131,18 @@ impl PathDiff {
     /// Note: Requires feature flag `path`
     #[cfg(feature = "path")]
     pub fn subset_eq_iter(
-        actual_root: impl Into<std::path::PathBuf>,
         pattern_root: impl Into<std::path::PathBuf>,
+        actual_root: impl Into<std::path::PathBuf>,
     ) -> impl Iterator<Item = Result<(std::path::PathBuf, std::path::PathBuf), Self>> {
-        let actual_root = actual_root.into();
         let pattern_root = pattern_root.into();
-        Self::subset_eq_iter_inner(actual_root, pattern_root)
+        let actual_root = actual_root.into();
+        Self::subset_eq_iter_inner(pattern_root, actual_root)
     }
 
     #[cfg(feature = "path")]
     pub(crate) fn subset_eq_iter_inner(
-        actual_root: std::path::PathBuf,
         expected_root: std::path::PathBuf,
+        actual_root: std::path::PathBuf,
     ) -> impl Iterator<Item = Result<(std::path::PathBuf, std::path::PathBuf), Self>> {
         let walker = Walk::new(&expected_root);
         walker.map(move |r| {
@@ -197,7 +197,7 @@ impl PathDiff {
                 FileType::Dir | FileType::Unknown | FileType::Missing => {}
             }
 
-            Ok((actual_path, expected_path))
+            Ok((expected_path, actual_path))
         })
     }
 
@@ -206,19 +206,19 @@ impl PathDiff {
     /// Note: Requires feature flag `path`
     #[cfg(feature = "path")]
     pub fn subset_matches_iter(
-        actual_root: impl Into<std::path::PathBuf>,
         pattern_root: impl Into<std::path::PathBuf>,
+        actual_root: impl Into<std::path::PathBuf>,
         substitutions: &crate::Substitutions,
     ) -> impl Iterator<Item = Result<(std::path::PathBuf, std::path::PathBuf), Self>> + '_ {
-        let actual_root = actual_root.into();
         let pattern_root = pattern_root.into();
-        Self::subset_matches_iter_inner(actual_root, pattern_root, substitutions)
+        let actual_root = actual_root.into();
+        Self::subset_matches_iter_inner(pattern_root, actual_root, substitutions)
     }
 
     #[cfg(feature = "path")]
     pub(crate) fn subset_matches_iter_inner(
-        actual_root: std::path::PathBuf,
         expected_root: std::path::PathBuf,
+        actual_root: std::path::PathBuf,
         substitutions: &crate::Substitutions,
     ) -> impl Iterator<Item = Result<(std::path::PathBuf, std::path::PathBuf), Self>> + '_ {
         let walker = Walk::new(&expected_root);
@@ -277,7 +277,7 @@ impl PathDiff {
                 FileType::Dir | FileType::Unknown | FileType::Missing => {}
             }
 
-            Ok((actual_path, expected_path))
+            Ok((expected_path, actual_path))
         })
     }
 }

--- a/crates/snapbox/src/report/diff.rs
+++ b/crates/snapbox/src/report/diff.rs
@@ -152,7 +152,7 @@ mod test {
    2    2   World
 ";
 
-        assert_eq!(actual_diff, expected_diff);
+        assert_eq!(expected_diff, actual_diff);
     }
 
     #[cfg(feature = "diff")]
@@ -181,7 +181,7 @@ mod test {
    2      - World
 ";
 
-        assert_eq!(actual_diff, expected_diff);
+        assert_eq!(expected_diff, actual_diff);
     }
 
     #[cfg(feature = "diff")]
@@ -211,7 +211,7 @@ mod test {
         2 + World
 ";
 
-        assert_eq!(actual_diff, expected_diff);
+        assert_eq!(expected_diff, actual_diff);
     }
 
     #[cfg(feature = "diff")]
@@ -241,6 +241,6 @@ mod test {
         2 + World∅
 ";
 
-        assert_eq!(actual_diff, expected_diff);
+        assert_eq!(expected_diff, actual_diff);
     }
 }

--- a/crates/snapbox/src/substitutions.rs
+++ b/crates/snapbox/src/substitutions.rs
@@ -399,7 +399,7 @@ mod test {
         ];
         for (line, pattern, expected) in cases {
             let actual = line_matches(line, pattern, &Substitutions::new());
-            assert_eq!(actual, expected, "line={:?}  pattern={:?}", line, pattern);
+            assert_eq!(expected, actual, "line={:?}  pattern={:?}", line, pattern);
         }
     }
 
@@ -414,7 +414,7 @@ mod test {
         ];
         for (key, expected) in cases {
             let actual = validate_key(key).is_ok();
-            assert_eq!(actual, expected, "key={:?}", key);
+            assert_eq!(expected, actual, "key={:?}", key);
         }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -490,7 +490,7 @@ impl Case {
                     substitutions,
                 ) {
                     match status {
-                        Ok((actual_path, expected_path)) => {
+                        Ok((expected_path, actual_path)) => {
                             fs.context.push(FileStatus::Ok {
                                 actual_path,
                                 expected_path,


### PR DESCRIPTION
While `actual == expected` reads more naturally to me, we are diffing as
`diff expected actual`, so being consistent with that.