### PR TITLE
fix(path): Prefer CARGO_TARGET_TMPDIR where available

### DIFF
--- a/crates/snapbox/src/path.rs
+++ b/crates/snapbox/src/path.rs
@@ -28,7 +28,11 @@ impl PathFixture {
 
     #[cfg(feature = "path")]
     pub fn mutable_temp() -> Result<Self, crate::Error> {
-        let temp = tempfile::tempdir().map_err(|e| e.to_string())?;
+        let temp = if let Some(parent) = std::env::var_os("CARGO_TARGET_TMPDIR") {
+            tempfile::tempdir_in(parent).map_err(|e| e.to_string())?
+        } else {
+            tempfile::tempdir().map_err(|e| e.to_string())?
+        };
         // We need to get the `/private` prefix on Mac so variable substitutions work
         // correctly
         let path = canonicalize(temp.path())


### PR DESCRIPTION
Rust 1.54.0 added `CARGO_TARGET_TMPDIR` for integration tests to not
pollute more general temporary locations.  This is what cargo's tests
use (albeit manually constructed), so we should probably do the same.

This will help to clean up the tmpdirs (`cargo clean`) when we leak
them, like on test failure.