### PR TITLE
fix: Implicitly create dest

### DIFF
--- a/crates/snapbox/src/path.rs
+++ b/crates/snapbox/src/path.rs
@@ -509,6 +509,8 @@ pub fn copy_template(
     let dest = dest.as_ref();
     let source = canonicalize(source)
         .map_err(|e| format!("Failed to canonicalize {}: {}", source.display(), e))?;
+    std::fs::create_dir_all(dest)
+        .map_err(|e| format!("Failed to create {}: {}", dest.display(), e))?;
     let dest = canonicalize(dest)
         .map_err(|e| format!("Failed to canonicalize {}: {}", dest.display(), e))?;
 


### PR DESCRIPTION
Originally, we could only populate a temp dir, so we knew it was
created.  Now we need to implicitly create it.