### PR TITLE
fix(path): Avoid mtime races

### DIFF
--- a/crates/snapbox/Cargo.toml
+++ b/crates/snapbox/Cargo.toml
@@ -44,7 +44,7 @@ harness = ["libtest-mimic", "ignore"]
 ## Smarter binary file detection
 detect-encoding = ["content_inspector"]
 ## Snapshotting of paths
-path = ["tempfile", "walkdir", "dunce", "detect-encoding"]
+path = ["tempfile", "walkdir", "dunce", "detect-encoding", "filetime"]
 ## Snapshotting of commands
 cmd = ["os_pipe", "wait-timeout"]
 
@@ -75,6 +75,7 @@ content_inspector = { version = "0.2.4", optional = true }
 tempfile = { version = "3.0", optional = true }
 walkdir = { version = "2.3.2", optional = true }
 dunce = { version = "1.0", optional = true }
+filetime = { version = "0.2", optional = true }
 
 os_pipe = { version = "1.0", optional = true }
 wait-timeout = { version = "0.2.0", optional = true }


### PR DESCRIPTION
This is inspired by cargo's tests