### PR TITLE
Better document `*.toml` format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,8 +125,10 @@
 //! - 1-to-1 with dumped results
 //! - `TRYCMD=overwrite` support
 //!
-//! [schema](https://github.com/assert-rs/trycmd/blob/main/schema.json):
+//! [See full schema](https://github.com/assert-rs/trycmd/blob/main/schema.json):
+//! Basic parameters:
 //! - `bin.name`: The name of the binary target from `Cargo.toml` to be used to find the file path
+//! - `args`: the arguments (including flags and option) passed to the binary
 //!
 //! #### `*.stdin`
 //!


### PR DESCRIPTION
Hello,

It was not clear to me how to pass `args` to the binary when using `*.toml` format, and since it is the argument most users will use, so it makes sense to directly put it in the doc.