### PR TITLE
add `DataFormat` enum

### DIFF
--- a/crates/snapbox/src/assert.rs
+++ b/crates/snapbox/src/assert.rs
@@ -1,3 +1,4 @@
+use crate::data::DataFormat;
 use crate::Action;
 
 /// Snapshot assertion against a file's contents
@@ -18,7 +19,7 @@ pub struct Assert {
     action_var: Option<String>,
     substitutions: crate::Substitutions,
     pub(crate) palette: crate::report::Palette,
-    pub(crate) binary: Option<bool>,
+    pub(crate) data_format: Option<DataFormat>,
 }
 
 /// # Assertions
@@ -111,7 +112,7 @@ impl Assert {
             Action::Ignore | Action::Verify | Action::Overwrite => {}
         }
 
-        let expected = crate::Data::read_from(pattern_path, self.binary);
+        let expected = crate::Data::read_from(pattern_path, self.data_format());
         let (expected, actual) = self.normalize_eq(expected, actual);
 
         self.do_action(
@@ -159,7 +160,7 @@ impl Assert {
             Action::Ignore | Action::Verify | Action::Overwrite => {}
         }
 
-        let expected = crate::Data::read_from(pattern_path, self.binary);
+        let expected = crate::Data::read_from(pattern_path, self.data_format());
         let (expected, actual) = self.normalize_match(expected, actual);
 
         self.do_action(
@@ -483,8 +484,16 @@ impl Assert {
     ///
     /// The default is to auto-detect
     pub fn binary(mut self, yes: bool) -> Self {
-        self.binary = Some(yes);
+        self.data_format = if yes {
+            Some(DataFormat::Binary)
+        } else {
+            Some(DataFormat::Text)
+        };
         self
+    }
+
+    pub(crate) fn data_format(&self) -> Option<DataFormat> {
+        self.data_format
     }
 }
 
@@ -495,7 +504,7 @@ impl Default for Assert {
             action_var: Default::default(),
             substitutions: Default::default(),
             palette: crate::report::Palette::auto(),
-            binary: Default::default(),
+            data_format: Default::default(),
         }
         .substitutions(crate::Substitutions::with_exe())
     }

--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -605,7 +605,7 @@ impl OutputAssert {
     #[track_caller]
     fn stdout_eq_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stdout.as_slice());
-        let expected = crate::Data::read_from(expected_path, self.config.binary);
+        let expected = crate::Data::read_from(expected_path, self.config.data_format());
         let (pattern, actual) = self.config.normalize_eq(expected, actual);
         self.config.do_action(
             pattern,
@@ -675,7 +675,7 @@ impl OutputAssert {
     #[track_caller]
     fn stdout_matches_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stdout.as_slice());
-        let expected = crate::Data::read_from(expected_path, self.config.binary);
+        let expected = crate::Data::read_from(expected_path, self.config.data_format());
         let (pattern, actual) = self.config.normalize_match(expected, actual);
         self.config.do_action(
             pattern,
@@ -745,7 +745,7 @@ impl OutputAssert {
     #[track_caller]
     fn stderr_eq_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stderr.as_slice());
-        let expected = crate::Data::read_from(expected_path, self.config.binary);
+        let expected = crate::Data::read_from(expected_path, self.config.data_format());
         let (pattern, actual) = self.config.normalize_eq(expected, actual);
         self.config.do_action(
             pattern,
@@ -815,7 +815,7 @@ impl OutputAssert {
     #[track_caller]
     fn stderr_matches_path_inner(self, expected_path: &std::path::Path) -> Self {
         let actual = crate::Data::from(self.output.stderr.as_slice());
-        let expected = crate::Data::read_from(expected_path, self.config.binary);
+        let expected = crate::Data::read_from(expected_path, self.config.data_format());
         let (pattern, actual) = self.config.normalize_match(expected, actual);
         self.config.do_action(
             pattern,

--- a/crates/snapbox/src/data.rs
+++ b/crates/snapbox/src/data.rs
@@ -12,6 +12,12 @@ enum DataInner {
     Text(String),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Copy, Hash)]
+pub enum DataFormat {
+    Binary,
+    Text,
+}
+
 impl Data {
     /// Mark the data as binary (no post-processing)
     pub fn binary(raw: impl Into<Vec<u8>>) -> Self {
@@ -33,18 +39,23 @@ impl Data {
     }
 
     /// Load test data from a file
-    pub fn read_from(path: &std::path::Path, binary: Option<bool>) -> Result<Self, crate::Error> {
-        let data = match binary {
-            Some(true) => {
-                let data = std::fs::read(&path)
-                    .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-                Self::binary(data)
-            }
-            Some(false) => {
-                let data = std::fs::read_to_string(&path)
-                    .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-                Self::text(data)
-            }
+    pub fn read_from(
+        path: &std::path::Path,
+        data_format: Option<DataFormat>,
+    ) -> Result<Self, crate::Error> {
+        let data = match data_format {
+            Some(df) => match df {
+                DataFormat::Binary => {
+                    let data = std::fs::read(&path)
+                        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+                    Self::binary(data)
+                }
+                DataFormat::Text => {
+                    let data = std::fs::read_to_string(&path)
+                        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+                    Self::text(data)
+                }
+            },
             None => {
                 let data = std::fs::read(&path)
                     .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;

--- a/crates/snapbox/src/harness.rs
+++ b/crates/snapbox/src/harness.rs
@@ -32,6 +32,7 @@
 //! }
 //! ```
 
+use crate::data::DataFormat;
 use crate::Action;
 
 pub struct Harness<S, T> {
@@ -212,7 +213,7 @@ impl Verifier {
         expected_path: &std::path::Path,
         actual: crate::Data,
     ) -> crate::Result<()> {
-        let expected = crate::Data::read_from(expected_path, Some(false))?
+        let expected = crate::Data::read_from(expected_path, Some(DataFormat::Text))?
             .map_text(crate::utils::normalize_lines);
 
         if expected != actual {

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -113,6 +113,7 @@ pub use action::Action;
 pub use action::DEFAULT_ACTION_ENV;
 pub use assert::Assert;
 pub use data::Data;
+pub use data::DataFormat;
 pub use error::Error;
 pub use snapbox_macros::debug;
 pub use substitutions::Substitutions;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,7 +19,10 @@ impl TryCmd {
                     .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
                 let one_shot = OneShot::parse_toml(&raw)?;
                 let mut sequence: Self = one_shot.into();
-                let is_binary = sequence.steps[0].binary;
+                let is_binary = match sequence.steps[0].binary {
+                    true => snapbox::DataFormat::Binary,
+                    false => snapbox::DataFormat::Text,
+                };
 
                 if sequence.steps[0].stdin.is_none() {
                     let stdin_path = path.with_extension("stdin");
@@ -60,7 +63,7 @@ impl TryCmd {
 
                 sequence
             } else if ext == std::ffi::OsStr::new("trycmd") || ext == std::ffi::OsStr::new("md") {
-                let raw = crate::Data::read_from(path, Some(false))?
+                let raw = crate::Data::read_from(path, Some(snapbox::DataFormat::Text))?
                     .map_text(snapbox::utils::normalize_lines)
                     .into_string()
                     .unwrap();
@@ -147,7 +150,7 @@ impl TryCmd {
                         .to_owned();
                     // Add back trailing newline removed when parsing
                     stdout.push('\n');
-                    let mut raw = crate::Data::read_from(path, Some(false))?
+                    let mut raw = crate::Data::read_from(path, Some(snapbox::DataFormat::Text))?
                         .map_text(snapbox::utils::normalize_lines);
                     replace_lines(&mut raw, line_nums, &stdout)?;
                     raw.write_to(path)?;


### PR DESCRIPTION
This adds a `DataFormat` enum to help with adding new data formats. This allows a user to specify what data format they want not just binary or text. Suggested in [this comment](https://github.com/assert-rs/trycmd/pull/106#discussion_r920180301)