### PR TITLE
refactor(snapbox)!: Change `as_bytes` to `to_bytes`

### DIFF
--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -325,7 +325,7 @@ impl Command {
         // before we read. Here we do this by dropping the Command object.
         drop(self.cmd);
 
-        let (stdout, stderr) = process_io(&mut child, self.stdin.as_ref().map(|d| d.as_bytes()))?;
+        let (stdout, stderr) = process_io(&mut child, self.stdin.as_ref().map(|d| d.to_bytes()))?;
 
         let status = wait(child, self.timeout)?;
         let _stdout = stdout
@@ -350,7 +350,7 @@ impl Command {
         self.cmd.stderr(std::process::Stdio::piped());
         let mut child = self.cmd.spawn()?;
 
-        let (stdout, stderr) = process_io(&mut child, self.stdin.as_ref().map(|d| d.as_bytes()))?;
+        let (stdout, stderr) = process_io(&mut child, self.stdin.as_ref().map(|d| d.to_bytes()))?;
 
         let status = wait(child, self.timeout)?;
         let stdout = stdout
@@ -370,11 +370,10 @@ impl Command {
 
 fn process_io(
     child: &mut std::process::Child,
-    input: Option<&[u8]>,
+    input: Option<Vec<u8>>,
 ) -> std::io::Result<(Stream, Stream)> {
     use std::io::Write;
 
-    let input = input.map(|b| b.to_owned());
     let stdin = input.and_then(|i| {
         child
             .stdin

--- a/crates/snapbox/src/data.rs
+++ b/crates/snapbox/src/data.rs
@@ -72,7 +72,7 @@ impl Data {
                 format!("Failed to create parent dir for {}: {}", path.display(), e)
             })?;
         }
-        std::fs::write(path, self.as_bytes())
+        std::fs::write(path, self.to_bytes())
             .map_err(|e| format!("Failed to write {}: {}", path.display(), e).into())
     }
 
@@ -139,10 +139,10 @@ impl Data {
         }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn to_bytes(&self) -> Vec<u8> {
         match &self.inner {
-            DataInner::Binary(data) => data,
-            DataInner::Text(data) => data.as_bytes(),
+            DataInner::Binary(data) => data.clone(),
+            DataInner::Text(data) => data.clone().into_bytes(),
         }
     }
 }


### PR DESCRIPTION
This renames `as_bytes` to `to_bytes` so we can write out to disk `Data` formats that will need more work to be serialized, like json.

These changes were motivated by [this comment](https://github.com/assert-rs/trycmd/issues/92#issuecomment-1188094231)