### PR TITLE
fix clippy warning

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -178,7 +178,7 @@ impl TryCmd {
                 let tick_end = line
                     .char_indices()
                     .find_map(|(i, c)| (c != '`').then(|| i))
-                    .unwrap_or_else(|| line.len());
+                    .unwrap_or(line.len());
                 if 3 <= tick_end {
                     fence_pattern = line[..tick_end].to_owned();
                     let raw = line[tick_end..].trim();


### PR DESCRIPTION
Clippy was throwing a warning about "unnecessary closure used to substitute value for `Option::None`". This fixes the warning by using the suggestion Clippy gave.

<details><summary>Full Warning</summary>
<p>

```
warning: unnecessary closure used to substitute value for `Option::None`
   --> src/schema.rs:178:32
    |
178 |                   let tick_end = line
    |  ________________________________^
179 | |                     .char_indices()
180 | |                     .find_map(|(i, c)| (c != '`').then(|| i))
181 | |                     .unwrap_or_else(|| line.len());
    | |______________________----------------------------^
    |                        |
    |                        help: use `unwrap_or(..)` instead: `unwrap_or(line.len())`
    |
    = note: `#[warn(clippy::unnecessary_lazy_evaluations)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
```

</p>
</details>
