### PR TITLE
feat(diff): Elide long sections of unchanged output

### DIFF
--- a/crates/snapbox/src/report/diff.rs
+++ b/crates/snapbox/src/report/diff.rs
@@ -47,9 +47,13 @@ fn write_diff_inner(
     actual_name: Option<&dyn std::fmt::Display>,
     palette: crate::report::Palette,
 ) -> Result<(), std::fmt::Error> {
+    let timeout = std::time::Duration::from_millis(500);
+    let min_elide = 20;
+    let context = 5;
+
     let changes = similar::TextDiff::configure()
         .algorithm(similar::Algorithm::Patience)
-        .timeout(std::time::Duration::from_millis(500))
+        .timeout(timeout)
         .newline_terminated(false)
         .diff_lines(expected, actual);
 
@@ -72,8 +76,63 @@ fn write_diff_inner(
     } else {
         writeln!(writer, "{}", palette.error(format_args!("+++ Actual")))?;
     }
-    for op in changes.ops() {
-        for change in changes.iter_inline_changes(op) {
+    let changes = changes
+        .ops()
+        .iter()
+        .flat_map(|op| changes.iter_inline_changes(op))
+        .collect::<Vec<_>>();
+    let tombstones = if min_elide < changes.len() {
+        let mut tombstones = vec![true; changes.len()];
+
+        let mut counter = context;
+        for (i, change) in changes.iter().enumerate() {
+            match change.tag() {
+                similar::ChangeTag::Insert | similar::ChangeTag::Delete => {
+                    counter = context;
+                    tombstones[i] = false;
+                }
+                similar::ChangeTag::Equal => {
+                    if counter != 0 {
+                        tombstones[i] = false;
+                        counter -= 1;
+                    }
+                }
+            }
+        }
+
+        let mut counter = context;
+        for (i, change) in changes.iter().enumerate().rev() {
+            match change.tag() {
+                similar::ChangeTag::Insert | similar::ChangeTag::Delete => {
+                    counter = context;
+                    tombstones[i] = false;
+                }
+                similar::ChangeTag::Equal => {
+                    if counter != 0 {
+                        tombstones[i] = false;
+                        counter -= 1;
+                    }
+                }
+            }
+        }
+        tombstones
+    } else {
+        Vec::new()
+    };
+
+    let mut elided = false;
+    for (i, change) in changes.into_iter().enumerate() {
+        if tombstones.get(i).copied().unwrap_or(false) {
+            if !elided {
+                let sign = "⋮";
+
+                write!(writer, "{:>4} ", " ",)?;
+                write!(writer, "{:>4} ", " ",)?;
+                writeln!(writer, "{}", palette.hint(sign))?;
+            }
+            elided = true;
+        } else {
+            elided = false;
             match change.tag() {
                 similar::ChangeTag::Insert => {
                     write_change(writer, change, "+", palette.actual, palette.error, palette)?;
@@ -239,6 +298,85 @@ mod test {
    1    1 | Hello
    2      - World
         2 + World∅
+";
+
+        assert_eq!(expected_diff, actual_diff);
+    }
+
+    #[cfg(feature = "diff")]
+    #[test]
+    fn diff_eq_elided() {
+        let mut expected = String::new();
+        expected.push_str("Hello\n");
+        for i in 0..20 {
+            expected.push_str(&i.to_string());
+            expected.push('\n');
+        }
+        expected.push_str("World\n");
+        for i in 0..20 {
+            expected.push_str(&i.to_string());
+            expected.push('\n');
+        }
+        expected.push_str("!\n");
+        let expected_name = "A";
+
+        let mut actual = String::new();
+        actual.push_str("Goodbye\n");
+        for i in 0..20 {
+            actual.push_str(&i.to_string());
+            actual.push('\n');
+        }
+        actual.push_str("Moon\n");
+        for i in 0..20 {
+            actual.push_str(&i.to_string());
+            actual.push('\n');
+        }
+        actual.push_str("?\n");
+        let actual_name = "B";
+
+        let palette = crate::report::Palette::never();
+
+        let mut actual_diff = String::new();
+        write_diff_inner(
+            &mut actual_diff,
+            &expected,
+            &actual,
+            Some(&expected_name),
+            Some(&actual_name),
+            palette,
+        )
+        .unwrap();
+        let expected_diff = "
+---- expected: A
+++++ actual:   B
+   1      - Hello
+        1 + Goodbye
+   2    2 | 0
+   3    3 | 1
+   4    4 | 2
+   5    5 | 3
+   6    6 | 4
+          ⋮
+  17   17 | 15
+  18   18 | 16
+  19   19 | 17
+  20   20 | 18
+  21   21 | 19
+  22      - World
+       22 + Moon
+  23   23 | 0
+  24   24 | 1
+  25   25 | 2
+  26   26 | 3
+  27   27 | 4
+          ⋮
+  38   38 | 15
+  39   39 | 16
+  40   40 | 17
+  41   41 | 18
+  42   42 | 19
+  43      - !
+       43 + ?
 ";
 
         assert_eq!(expected_diff, actual_diff);


### PR DESCRIPTION
For now, this isn't configurable.  The defaults favor showing as much
context as possible.