### PR TITLE
refactor(snapbox): Changes to normalization

### DIFF
--- a/crates/snapbox/src/assert.rs
+++ b/crates/snapbox/src/assert.rs
@@ -1,4 +1,4 @@
-use crate::data::DataFormat;
+use crate::data::{DataFormat, NormalizeMatches, NormalizeNewlines, NormalizePaths};
 use crate::Action;
 
 /// Snapshot assertion against a file's contents
@@ -178,16 +178,14 @@ impl Assert {
         expected: crate::Result<crate::Data>,
         mut actual: crate::Data,
     ) -> (crate::Result<crate::Data>, crate::Data) {
-        let expected = expected.map(|d| d.map_text(crate::utils::normalize_lines));
+        let expected = expected.map(|d| d.normalize(NormalizeNewlines));
         // On `expected` being an error, make a best guess
         let format = expected
             .as_ref()
             .map(|d| d.format())
             .unwrap_or(DataFormat::Text);
 
-        actual = actual
-            .try_coerce(format)
-            .map_text(|s| crate::utils::normalize_lines(s));
+        actual = actual.try_coerce(format).normalize(NormalizeNewlines);
 
         (expected, actual)
     }
@@ -197,17 +195,23 @@ impl Assert {
         expected: crate::Result<crate::Data>,
         mut actual: crate::Data,
     ) -> (crate::Result<crate::Data>, crate::Data) {
-        let expected = expected.map(|d| d.map_text(crate::utils::normalize_lines));
+        let expected = expected.map(|d| d.normalize(NormalizeNewlines));
         // On `expected` being an error, make a best guess
         if let (Some(expected), format) = expected
             .as_ref()
             .map(|d| (d.as_str(), d.format()))
             .unwrap_or((Some(""), DataFormat::Text))
         {
+            actual = actual.try_coerce(format);
+            if self.normalize_paths {
+                actual = actual.normalize(NormalizePaths);
+            }
             actual = actual
-                .try_coerce(format)
-                .map_text(|s| self.normalize_text(s))
-                .map_text(|t| self.substitutions.normalize(t, expected));
+                .normalize(NormalizeNewlines)
+                .normalize(NormalizeMatches::new(
+                    &self.substitutions,
+                    &crate::Data::text(expected),
+                ));
         }
 
         (expected, actual)
@@ -289,14 +293,6 @@ impl Assert {
         } else {
             Ok(())
         }
-    }
-
-    fn normalize_text(&self, data: &str) -> String {
-        let mut data = crate::utils::normalize_lines(data);
-        if self.normalize_paths {
-            data = crate::utils::normalize_paths(&data);
-        }
-        data
     }
 }
 

--- a/crates/snapbox/src/data.rs
+++ b/crates/snapbox/src/data.rs
@@ -79,11 +79,8 @@ impl Data {
     /// Post-process text
     ///
     /// See [utils][crate::utils]
-    pub fn map_text(self, op: impl FnOnce(&str) -> String) -> Self {
-        match self.inner {
-            DataInner::Binary(data) => Self::binary(data),
-            DataInner::Text(data) => Self::text(op(&data)),
-        }
+    pub fn normalize(self, op: impl Normalize) -> Self {
+        op.normalize(self)
     }
 
     /// Coerce to a string
@@ -203,6 +200,64 @@ impl<'s> From<&'s String> for Data {
 impl<'s> From<&'s str> for Data {
     fn from(other: &'s str) -> Self {
         other.to_owned().into()
+    }
+}
+
+pub trait Normalize {
+    fn normalize(&self, data: Data) -> Data;
+}
+
+pub struct NormalizeNewlines;
+impl Normalize for NormalizeNewlines {
+    fn normalize(&self, data: Data) -> Data {
+        match data.inner {
+            DataInner::Binary(bin) => Data::binary(bin),
+            DataInner::Text(text) => {
+                let lines = crate::utils::normalize_lines(&text);
+                Data::text(lines)
+            }
+        }
+    }
+}
+
+pub struct NormalizePaths;
+impl Normalize for NormalizePaths {
+    fn normalize(&self, data: Data) -> Data {
+        match data.inner {
+            DataInner::Binary(bin) => Data::binary(bin),
+            DataInner::Text(text) => {
+                let lines = crate::utils::normalize_paths(&text);
+                Data::text(lines)
+            }
+        }
+    }
+}
+
+pub struct NormalizeMatches<'a> {
+    substitutions: &'a crate::Substitutions,
+    pattern: &'a Data,
+}
+
+impl<'a> NormalizeMatches<'a> {
+    pub fn new(substitutions: &'a crate::Substitutions, pattern: &'a Data) -> Self {
+        NormalizeMatches {
+            substitutions,
+            pattern,
+        }
+    }
+}
+
+impl Normalize for NormalizeMatches<'_> {
+    fn normalize(&self, data: Data) -> Data {
+        match data.inner {
+            DataInner::Binary(bin) => Data::binary(bin),
+            DataInner::Text(text) => {
+                let lines = self
+                    .substitutions
+                    .normalize(&text, self.pattern.as_str().unwrap());
+                Data::text(lines)
+            }
+        }
     }
 }
 

--- a/crates/snapbox/src/data.rs
+++ b/crates/snapbox/src/data.rs
@@ -110,13 +110,13 @@ impl Data {
         }
     }
 
-    /// Return the underlying `str`
+    /// Return the underlying `String`
     ///
-    /// Note: this will not inspect binary data for being a valid `str`.
-    pub fn as_str(&self) -> Option<&str> {
+    /// Note: this will not inspect binary data for being a valid `String`.
+    pub fn render(&self) -> Option<String> {
         match &self.inner {
             DataInner::Binary(_) => None,
-            DataInner::Text(data) => Some(data.as_str()),
+            DataInner::Text(data) => Some(data.to_owned()),
         }
     }
 
@@ -260,7 +260,7 @@ impl Normalize for NormalizeMatches<'_> {
             DataInner::Text(text) => {
                 let lines = self
                     .substitutions
-                    .normalize(&text, self.pattern.as_str().unwrap());
+                    .normalize(&text, &self.pattern.render().unwrap());
                 Data::text(lines)
             }
         }

--- a/crates/snapbox/src/data.rs
+++ b/crates/snapbox/src/data.rs
@@ -18,6 +18,12 @@ pub enum DataFormat {
     Text,
 }
 
+impl Default for DataFormat {
+    fn default() -> Self {
+        DataFormat::Text
+    }
+}
+
 impl Data {
     /// Mark the data as binary (no post-processing)
     pub fn binary(raw: impl Into<Vec<u8>>) -> Self {

--- a/crates/snapbox/src/harness.rs
+++ b/crates/snapbox/src/harness.rs
@@ -32,7 +32,7 @@
 //! }
 //! ```
 
-use crate::data::DataFormat;
+use crate::data::{DataFormat, NormalizeNewlines};
 use crate::Action;
 
 pub struct Harness<S, T> {
@@ -122,7 +122,7 @@ where
             match (self.test)(&test.data.fixture) {
                 Ok(actual) => {
                     let actual = actual.to_string();
-                    let actual = crate::Data::text(actual).map_text(crate::utils::normalize_lines);
+                    let actual = crate::Data::text(actual).normalize(NormalizeNewlines);
                     let verify = Verifier::new()
                         .palette(crate::report::Palette::auto())
                         .action(self.action);
@@ -214,7 +214,7 @@ impl Verifier {
         actual: crate::Data,
     ) -> crate::Result<()> {
         let expected = crate::Data::read_from(expected_path, Some(DataFormat::Text))?
-            .map_text(crate::utils::normalize_lines);
+            .normalize(NormalizeNewlines);
 
         if expected != actual {
             let mut buf = String::new();

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -114,6 +114,7 @@ pub use action::DEFAULT_ACTION_ENV;
 pub use assert::Assert;
 pub use data::Data;
 pub use data::DataFormat;
+pub use data::{Normalize, NormalizeMatches, NormalizeNewlines, NormalizePaths};
 pub use error::Error;
 pub use snapbox_macros::debug;
 pub use substitutions::Substitutions;

--- a/crates/snapbox/src/path.rs
+++ b/crates/snapbox/src/path.rs
@@ -261,16 +261,11 @@ impl PathDiff {
                         .map(|d| d.normalize(NormalizeNewlines))
                         .map_err(Self::Failure)?;
 
-                    if let (Some(expected), format) = (expected.as_str(), expected.format()) {
-                        actual = actual
-                            .try_coerce(format)
-                            .normalize(NormalizePaths)
-                            .normalize(NormalizeNewlines)
-                            .normalize(NormalizeMatches::new(
-                                substitutions,
-                                &crate::Data::text(expected),
-                            ));
-                    }
+                    actual = actual
+                        .try_coerce(expected.format())
+                        .normalize(NormalizePaths)
+                        .normalize(NormalizeNewlines)
+                        .normalize(NormalizeMatches::new(substitutions, &expected));
 
                     if expected != actual {
                         return Err(Self::ContentMismatch {

--- a/crates/snapbox/src/path.rs
+++ b/crates/snapbox/src/path.rs
@@ -1,5 +1,6 @@
 //! Initialize working directories and assert on how they've changed
 
+use crate::data::{NormalizeMatches, NormalizeNewlines, NormalizePaths};
 /// Working directory for tests
 #[derive(Debug)]
 pub struct PathFixture(PathFixtureInner);
@@ -179,12 +180,12 @@ impl PathDiff {
                         crate::Data::read_from(&actual_path, None).map_err(Self::Failure)?;
 
                     let expected = crate::Data::read_from(&expected_path, None)
-                        .map(|d| d.map_text(crate::utils::normalize_lines))
+                        .map(|d| d.normalize(NormalizeNewlines))
                         .map_err(Self::Failure)?;
 
                     actual = actual
                         .try_coerce(expected.format())
-                        .map_text(crate::utils::normalize_lines);
+                        .normalize(NormalizeNewlines);
 
                     if expected != actual {
                         return Err(Self::ContentMismatch {
@@ -257,14 +258,18 @@ impl PathDiff {
                         crate::Data::read_from(&actual_path, None).map_err(Self::Failure)?;
 
                     let expected = crate::Data::read_from(&expected_path, None)
-                        .map(|d| d.map_text(crate::utils::normalize_lines))
+                        .map(|d| d.normalize(NormalizeNewlines))
                         .map_err(Self::Failure)?;
 
                     if let (Some(expected), format) = (expected.as_str(), expected.format()) {
                         actual = actual
                             .try_coerce(format)
-                            .map_text(crate::utils::normalize_text)
-                            .map_text(|t| substitutions.normalize(t, expected));
+                            .normalize(NormalizePaths)
+                            .normalize(NormalizeNewlines)
+                            .normalize(NormalizeMatches::new(
+                                substitutions,
+                                &crate::Data::text(expected),
+                            ));
                     }
 
                     if expected != actual {

--- a/crates/snapbox/src/report/diff.rs
+++ b/crates/snapbox/src/report/diff.rs
@@ -9,11 +9,11 @@ pub fn write_diff(
     #[allow(unused_mut)]
     let mut rendered = false;
     #[cfg(feature = "diff")]
-    if let (Some(expected), Some(actual)) = (expected.as_str(), actual.as_str()) {
+    if let (Some(expected), Some(actual)) = (expected.render(), actual.render()) {
         write_diff_inner(
             writer,
-            expected,
-            actual,
+            &expected,
+            &actual,
             expected_name,
             actual_name,
             palette,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -420,12 +420,11 @@ impl Case {
         }
 
         if let Some(expected_content) = expected_content {
-            if expected_content.as_str().is_some() {
-                stream.content = stream.content.normalize(snapbox::NormalizeMatches::new(
-                    substitutions,
-                    expected_content,
-                ));
-            }
+            stream.content = stream.content.normalize(snapbox::NormalizeMatches::new(
+                substitutions,
+                expected_content,
+            ));
+
             if stream.content != *expected_content {
                 stream.status = StreamStatus::Expected(expected_content.clone());
                 return Some(stream);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -146,10 +146,7 @@ impl TryCmd {
                         .expected_stdout_source
                         .clone()
                         .expect("always present for .trycmd");
-                    let mut stdout = stdout
-                        .as_str()
-                        .expect("already converted to Text")
-                        .to_owned();
+                    let mut stdout = stdout.render().expect("at least Text");
                     // Add back trailing newline removed when parsing
                     stdout.push('\n');
                     let raw = std::fs::read_to_string(path)
@@ -327,7 +324,7 @@ fn overwrite_toml_output(
         let output_path = path.with_extension(output_ext);
         if output_path.exists() {
             output.write_to(&output_path)?;
-        } else if let Some(output) = output.as_str() {
+        } else if let Some(output) = output.render() {
             let raw = std::fs::read_to_string(path)
                 .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
             let mut doc = raw

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -2,6 +2,7 @@
 //!
 //! [`OneShot`] is the top-level item in the `cmd.toml` files.
 
+use snapbox::{NormalizeNewlines, NormalizePaths};
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 
@@ -40,7 +41,8 @@ impl TryCmd {
                     let stdout = if stdout_path.exists() {
                         Some(
                             crate::Data::read_from(&stdout_path, Some(is_binary))?
-                                .map_text(snapbox::utils::normalize_text),
+                                .normalize(NormalizePaths)
+                                .normalize(NormalizeNewlines),
                         )
                     } else {
                         None
@@ -53,7 +55,8 @@ impl TryCmd {
                     let stderr = if stderr_path.exists() {
                         Some(
                             crate::Data::read_from(&stderr_path, Some(is_binary))?
-                                .map_text(snapbox::utils::normalize_text),
+                                .normalize(NormalizePaths)
+                                .normalize(NormalizeNewlines),
                         )
                     } else {
                         None


### PR DESCRIPTION
This is a part of #92.

This PR is to help move forward the effort with supporting structured data formats. Part of this effort showed that there needed to be a better way to specify what normalization operation was wanted and later to unify what the operations are doing. 


- Abstract lower level `map_text` calls as `normalize` with operation types
  - By providing build blocks before, we were hoping to allow people to plug in their own normalization routines.  However, when we add structured data support, it will need to operate on internal data initially as we work out details, so we're making all of the normalization logic private, just allowing the caller to which built-in normalization can be done.
- change `as_str` to `try_string` and update its return to be `Option<String>`
  - The original intent of `as_str` was for outputting Diffs. This had to be changed to `String` since there are some formats that have borrowing issues with `&str`. By changing to `String` it allows support for more formats


