### PR TITLE
refactor(snapbox): Remove `into_string`

### DIFF
--- a/crates/snapbox/src/data.rs
+++ b/crates/snapbox/src/data.rs
@@ -89,27 +89,6 @@ impl Data {
         op.normalize(self)
     }
 
-    /// Coerce to a string
-    ///
-    /// Note: this will **not** do a binary-content check
-    pub fn make_text(&mut self) -> Result<(), std::str::Utf8Error> {
-        *self = Self::text(std::mem::take(self).into_string()?);
-        Ok(())
-    }
-
-    /// Coerce to a string
-    ///
-    /// Note: this will **not** do a binary-content check
-    pub fn into_string(self) -> Result<String, std::str::Utf8Error> {
-        match self.inner {
-            DataInner::Binary(data) => {
-                let data = String::from_utf8(data).map_err(|e| e.utf8_error())?;
-                Ok(data)
-            }
-            DataInner::Text(data) => Ok(data),
-        }
-    }
-
     /// Return the underlying `String`
     ///
     /// Note: this will not inspect binary data for being a valid `String`.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,7 +2,7 @@ use std::io::prelude::*;
 
 use rayon::prelude::*;
 use snapbox::path::FileType;
-use snapbox::{NormalizeNewlines, NormalizePaths};
+use snapbox::{DataFormat, NormalizeNewlines, NormalizePaths};
 
 #[derive(Debug)]
 pub(crate) struct Runner {
@@ -720,11 +720,11 @@ struct Stream {
 
 impl Stream {
     fn make_text(mut self) -> Self {
-        if self.content.make_text().is_err() {
-            self.status = StreamStatus::Failure("invalid UTF-8".into());
+        let content = self.content.try_coerce(DataFormat::Text);
+        if content.format() != DataFormat::Text {
+            self.status = StreamStatus::Failure("Unable to convert underlying Data to Text".into());
         }
-        self.content = self
-            .content
+        self.content = content
             .normalize(NormalizePaths)
             .normalize(NormalizeNewlines);
         self


### PR DESCRIPTION
@epage [noticed](https://github.com/assert-rs/trycmd/pull/106#discussion_r951809165) that `into_text` was only being used in `make_text` and `make_text` were only being used in one place and both could be removed by switching the single caller of `make_text` to use `try_coerce` 

This removes `into_string` and  `make_text`, and updates the one caller of `make_text` to use `try_coerce` instead