### PR TITLE
fix: Re-add ignore reporting

### DIFF
--- a/crates/snapbox/src/harness.rs
+++ b/crates/snapbox/src/harness.rs
@@ -120,6 +120,7 @@ where
                     verify.verify(&case.expected, actual)?;
                     Ok(())
                 })
+                .with_ignored_flag(self.action == Action::Ignore)
             })
             .collect();
 


### PR DESCRIPTION
This will now report back to the user if `SNAPSHOTS=ignore` is used