### PR TITLE
Revamp intro docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,19 @@ results, taking inspiration from
 
 ## Example
 
-Here's a trivial example:
-
 ```rust,no_run
 #[test]
-fn cli_tests() {
-    trycmd::TestCases::new()
-        .case("tests/cmd/*.trycmd");
+fn readme() {
+    trycmd::TestCases::new().case("README.md");
 }
+```
+
+The README is then executed as a trycmd test:
+
+```console,ignore
+$ my-echo-binary World
+Hello World!
+
 ```
 
 See the [docs](http://docs.rs/trycmd) for more.

--- a/examples/simple.md
+++ b/examples/simple.md
@@ -1,0 +1,37 @@
+With a trycmd case for your README file:
+
+```rust,no_run
+#[test]
+fn readme() {
+    // Paths are relative to the crate root
+    trycmd::TestCases::new().case("README.md");
+}
+```
+
+You can now write a test for it:
+
+```console
+$ simple World
+Hello World!
+
+$ simple Ferris
+Hello Ferris!
+
+$ simple
+? 1
+Must supply exactly one argument.
+
+```
+
+That's right, the file you're reading right now is a trycmd test!
+
+It uses the trycmd format to run code blocks with the `console` or `trycmd` language:
+
+~~~md
+```console
+$ command ...
+```
+~~~
+
+> Note: since this demo code lives in `examples/simple.md`, the actual `simple` binary is
+> in `examples/simple.rs` and the trycmd case lives in `tests/example_tests.rs`.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() == 2 {
+        println!("Hello {}!", args[1]);
+    } else {
+        eprintln!("Must supply exactly one argument.");
+        std::process::exit(1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,10 @@
 //! #[test]
 //! fn cli_tests() {
 //!     trycmd::TestCases::new()
-//!         .case("tests/cmd/*.trycmd");
+//!         // Write your .trycmd files in the tests/cmd/ directory
+//!         .case("tests/cmd/*.trycmd")
+//!         // OR: test the commands in your README file
+//!         .case("README.md");
 //! }
 //! ```
 //!
@@ -104,20 +107,15 @@
 //! to allow spaces.  The first argument is the program to run which maps to `bin.name` in the
 //! `.toml` file.
 //!
-//! Example:
-//! With the following code:
-//! ```rust,ignore
-//! println!("{}", message);
+//! #### Example
+//!
+//! Let's say you have the following Rust binary called `simple`:
+//!
+//! ```rust,no_run
+#![doc = include_str!("../examples/simple.rs")]
 //! ```
 //!
-//! You get the following:
-//! ~~~md
-//! ```console
-//! $ my-cmd --print 'Hello World'
-//! Hello
-//!
-//! ```
-//! ~~~
+#![doc = include_str!("../examples/simple.md")]
 //!
 //! ### `*.toml`
 //!


### PR DESCRIPTION
Closes #141. Content elision still needs work, but I'll leave that to #140.

I think it's now clear how to use the library. I unfortunately couldn't figure out how to include the `simple.md` file into the README which means their contents are duplicated. Very annoying but oh well.