### PR TITLE
Errorfix(trycmd): Error, instead of ignore, unknown bins

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -102,6 +102,12 @@
       "description": "Target under test",
       "oneOf": [
         {
+          "type": "string",
+          "enum": [
+            "ignore"
+          ]
+        },
+        {
           "type": "object",
           "required": [
             "path"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -36,6 +36,7 @@ impl BinRegistry {
                 let bin = self.resolve_name(&name);
                 Ok(bin)
             }
+            crate::schema::Bin::Ignore => Ok(crate::schema::Bin::Ignore),
             crate::schema::Bin::Error(err) => Err(err),
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -321,6 +321,19 @@ impl Case {
             return Ok(output);
         }
 
+        match &step.bin {
+            // Will be handled by `Step::to_command`
+            Some(crate::schema::Bin::Path(_))
+            | Some(crate::schema::Bin::Name(_))
+            | Some(crate::schema::Bin::Error(_))
+            | None => {}
+            Some(crate::schema::Bin::Ignore) => {
+                // Unhandled by resolve
+                assert_eq!(output.spawn.status, SpawnStatus::Skipped);
+                return Ok(output);
+            }
+        }
+
         let cmd = step.to_command(cwd).map_err(|e| output.clone().error(e))?;
         let cmd_output = cmd
             .output()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -321,20 +321,6 @@ impl Case {
             return Ok(output);
         }
 
-        #[allow(unused_variables)]
-        match &step.bin {
-            Some(crate::schema::Bin::Path(_)) => {}
-            Some(crate::schema::Bin::Name(name)) => {
-                // Unhandled by resolve
-                snapbox::debug!("bin={:?} not found", name);
-                assert_eq!(output.spawn.status, SpawnStatus::Skipped);
-                return Ok(output);
-            }
-            Some(crate::schema::Bin::Error(_)) => {}
-            // Unlike `Name`, this always represents a bug
-            None => {}
-        }
-
         let cmd = step.to_command(cwd).map_err(|e| output.clone().error(e))?;
         let cmd_output = cmd
             .output()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -448,6 +448,7 @@ impl Step {
         let bin = match &self.bin {
             Some(Bin::Path(path)) => Ok(path.clone()),
             Some(Bin::Name(name)) => Err(format!("Unknown bin.name = {}", name).into()),
+            Some(Bin::Ignore) => Err("Internal error: tried to run an ignored bin".into()),
             Some(Bin::Error(err)) => Err(err.clone()),
             None => Err("No bin specified".into()),
         }?;
@@ -683,6 +684,7 @@ impl Env {
 pub enum Bin {
     Path(std::path::PathBuf),
     Name(String),
+    Ignore,
     #[serde(skip)]
     Error(crate::Error),
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -21,4 +21,5 @@ fn cli_tests() {
         t.skip("tests/cmd/timeout.toml");
     }
     t.extend_vars([("[EXAMPLE]", "example")]).unwrap();
+    t.register_bin("ignored-bin", trycmd::schema::Bin::Ignore);
 }

--- a/tests/cmd/ignored_bin.trycmd
+++ b/tests/cmd/ignored_bin.trycmd
@@ -1,0 +1,6 @@
+Ignored by test runner:
+```
+$ ignored-bin I have No Impact
+I'm ignored too
+
+```

--- a/tests/cmd/unresolved.trycmd
+++ b/tests/cmd/unresolved.trycmd
@@ -1,5 +1,0 @@
-Gracefully handle a non-existent name:
-```
-$ non-existent-name
-
-```


### PR DESCRIPTION
This was originally written this way to be a low effort way to ignore,
especially if you wanted a markdown block of code that interspersed
different commands.

This cane make it harder to root cause failures.  In the mean time, you can
- Mark the whole code fence as ignored
- Mark the status of the program as skipped
- Mark the binary as ignored (new)

Fixes #105