### PR TITLE
Revert "fix(trycmd): Error, instead of ignore, unknown bins"

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -322,11 +322,16 @@ impl Case {
         }
 
         match &step.bin {
-            // Will be handled by `Step::to_command`
-            Some(crate::schema::Bin::Path(_))
-            | Some(crate::schema::Bin::Name(_))
-            | Some(crate::schema::Bin::Error(_))
-            | None => {}
+            Some(crate::schema::Bin::Path(_)) => {}
+            Some(crate::schema::Bin::Name(_name)) => {
+                // Unhandled by resolve
+                snapbox::debug!("bin={:?} not found", _name);
+                assert_eq!(output.spawn.status, SpawnStatus::Skipped);
+                return Ok(output);
+            }
+            Some(crate::schema::Bin::Error(_)) => {}
+            // Unlike `Name`, this always represents a bug
+            None => {}
             Some(crate::schema::Bin::Ignore) => {
                 // Unhandled by resolve
                 assert_eq!(output.spawn.status, SpawnStatus::Skipped);

--- a/tests/cmd/unresolved.trycmd
+++ b/tests/cmd/unresolved.trycmd
@@ -1,0 +1,5 @@
+Gracefully handle a non-existent name:
+```
+$ non-existent-name
+
+```


### PR DESCRIPTION
This reverts commit bd6922457c7b37b2a62b42a10de51f74dc96be21.

When working on this, we forgot the case of conditionally existing examples.

#105 was re-opened.  As this turns an error into a working case, this shouldn't break compatibility.