### PR TITLE
Ignore every test under miri

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -23,11 +23,14 @@ impl RunnerSpec {
     pub(crate) fn case(
         &mut self,
         glob: &std::path::Path,
-        expected: Option<crate::schema::CommandStatus>,
+        #[cfg_attr(miri, allow(unused_variables))] expected: Option<crate::schema::CommandStatus>,
     ) {
         self.cases.push(CaseSpec {
             glob: glob.into(),
+            #[cfg(not(miri))]
             expected,
+            #[cfg(miri)]
+            expected: Some(crate::schema::CommandStatus::Skipped),
         });
     }
 


### PR DESCRIPTION
Turns out trycmd is still broken because of https://github.com/rayon-rs/rayon/issues/952, but that will presumably get fixed eventually.

Closes #152