### PR TITLE
snapbox: cfg out platform dependent deps

### DIFF
--- a/crates/snapbox/Cargo.toml
+++ b/crates/snapbox/Cargo.toml
@@ -88,8 +88,6 @@ filetime = { version = "0.2", optional = true }
 os_pipe = { version = "1.0", optional = true }
 wait-timeout = { version = "0.2.0", optional = true }
 escargot = { version = "0.5.7", optional = true }
-libc = { version = "0.2.137", optional = true }
-windows-sys = { version = "0.45.0", features = ["Win32_Foundation"], optional = true }
 
 backtrace = { version = "0.3", optional = true }
 
@@ -101,3 +99,9 @@ concolor = { version = "0.0.11", features = ["std"], optional = true }
 document-features = { version = "0.2.6", optional = true }
 
 serde_json = { version = "1.0.85", optional = true}
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.45.0", features = ["Win32_Foundation"], optional = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { version = "0.2.137", optional = true }


### PR DESCRIPTION
This prevents build of useless deps -> faster build