### PR TITLE
feat(snap): Allow compiling examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "content_inspector",
  "document-features",
  "dunce",
+ "escargot",
  "filetime",
  "ignore",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ diff = ["snapbox/diff"]
 filesystem = ["snapbox/path"]
 
 schema = ["dep:schemars", "dep:serde_json"]
-examples = ["dep:escargot"]
+examples = ["snapbox/examples"]
 debug = ["snapbox/debug"]
 
 [[bin]]

--- a/crates/snapbox/Cargo.toml
+++ b/crates/snapbox/Cargo.toml
@@ -48,6 +48,8 @@ detect-encoding = ["dep:content_inspector"]
 path = ["dep:tempfile", "dep:walkdir", "dep:dunce", "detect-encoding", "dep:filetime"]
 ## Snapshotting of commands
 cmd = ["dep:os_pipe", "dep:wait-timeout", "dep:libc", "dep:windows-sys"]
+## Building of examples for snapshotting
+examples = ["dep:escargot"]
 
 ## Snapshotting of json
 json = ["structured-data"]
@@ -85,6 +87,7 @@ filetime = { version = "0.2", optional = true }
 
 os_pipe = { version = "1.0", optional = true }
 wait-timeout = { version = "0.2.0", optional = true }
+escargot = { version = "0.5.7", optional = true }
 libc = { version = "0.2.137", optional = true }
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"], optional = true }
 

--- a/crates/snapbox/examples/example-fixture.rs
+++ b/crates/snapbox/examples/example-fixture.rs
@@ -1,0 +1,1 @@
+../src/bin/snap-fixture.rs

--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -1027,3 +1027,141 @@ fn target_dir() -> std::path::PathBuf {
         })
         .unwrap()
 }
+
+#[cfg(feature = "examples")]
+pub use examples::{compile_example, compile_examples};
+
+#[cfg(feature = "examples")]
+pub(crate) mod examples {
+    /// Prepare an example for testing
+    ///
+    /// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
+    /// will match the current target and profile but will not get feature flags.  Pass those arguments
+    /// to the compiler via `args`.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// snapbox::cmd::compile_example("example-fixture", []);
+    /// ```
+    #[cfg(feature = "examples")]
+    pub fn compile_example<'a>(
+        target_name: &str,
+        args: impl IntoIterator<Item = &'a str>,
+    ) -> Result<std::path::PathBuf, crate::Error> {
+        crate::debug!("Compiling example {}", target_name);
+        let messages = escargot::CargoBuild::new()
+            .current_target()
+            .current_release()
+            .example(target_name)
+            .args(args)
+            .exec()
+            .map_err(|e| crate::Error::new(e.to_string()))?;
+        for message in messages {
+            let message = message.map_err(|e| crate::Error::new(e.to_string()))?;
+            let message = message
+                .decode()
+                .map_err(|e| crate::Error::new(e.to_string()))?;
+            crate::debug!("Message: {:?}", message);
+            if let Some(bin) = decode_example_message(&message) {
+                let (name, bin) = bin?;
+                assert_eq!(target_name, name);
+                return bin;
+            }
+        }
+
+        Err(crate::Error::new(format!(
+            "Unknown error building example {}",
+            target_name
+        )))
+    }
+
+    /// Prepare all examples for testing
+    ///
+    /// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
+    /// will match the current target and profile but will not get feature flags.  Pass those arguments
+    /// to the compiler via `args`.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// let examples = snapbox::cmd::compile_examples([]).unwrap().collect::<Vec<_>>();
+    /// ```
+    #[cfg(feature = "examples")]
+    pub fn compile_examples<'a>(
+        args: impl IntoIterator<Item = &'a str>,
+    ) -> Result<
+        impl Iterator<Item = (String, Result<std::path::PathBuf, crate::Error>)>,
+        crate::Error,
+    > {
+        crate::debug!("Compiling examples");
+        let mut examples = std::collections::BTreeMap::new();
+
+        let messages = escargot::CargoBuild::new()
+            .current_target()
+            .current_release()
+            .examples()
+            .args(args)
+            .exec()
+            .map_err(|e| crate::Error::new(e.to_string()))?;
+        for message in messages {
+            let message = message.map_err(|e| crate::Error::new(e.to_string()))?;
+            let message = message
+                .decode()
+                .map_err(|e| crate::Error::new(e.to_string()))?;
+            crate::debug!("Message: {:?}", message);
+            if let Some(bin) = decode_example_message(&message) {
+                let (name, bin) = bin?;
+                examples.insert(name.to_owned(), bin);
+            }
+        }
+
+        Ok(examples.into_iter())
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn decode_example_message<'m>(
+        message: &'m escargot::format::Message,
+    ) -> Option<Result<(&'m str, Result<std::path::PathBuf, crate::Error>), crate::Error>> {
+        match message {
+            escargot::format::Message::CompilerMessage(msg) => {
+                let level = msg.message.level;
+                if level == escargot::format::diagnostic::DiagnosticLevel::Ice
+                    || level == escargot::format::diagnostic::DiagnosticLevel::Error
+                {
+                    let output = msg
+                        .message
+                        .rendered
+                        .as_deref()
+                        .unwrap_or_else(|| msg.message.message.as_ref())
+                        .to_owned();
+                    if is_example_target(&msg.target) {
+                        let bin = Err(crate::Error::new(output));
+                        Some(Ok((msg.target.name.as_ref(), bin)))
+                    } else {
+                        Some(Err(crate::Error::new(output)))
+                    }
+                } else {
+                    None
+                }
+            }
+            escargot::format::Message::CompilerArtifact(artifact) => {
+                if !artifact.profile.test && is_example_target(&artifact.target) {
+                    let path = artifact
+                        .executable
+                        .clone()
+                        .expect("cargo is new enough for this to be present");
+                    let bin = Ok(path.into_owned());
+                    Some(Ok((artifact.target.name.as_ref(), bin)))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn is_example_target(target: &escargot::format::Target) -> bool {
+        target.crate_types == ["bin"] && target.kind == ["example"]
+    }
+}

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -3,151 +3,49 @@
 #[doc(inline)]
 pub use snapbox::cmd::cargo_bin;
 
+/// Prepare an example for testing
+///
+/// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
+/// will match the current target and profile but will not get feature flags.  Pass those arguments
+/// to the compiler via `args`.
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// #[test]
+/// fn cli_tests() {
+///     trycmd::TestCases::new()
+///         .register_bin("example-fixture", trycmd::cargo::compile_example("example-fixture", []))
+///         .case("examples/cmd/*.trycmd");
+/// }
+/// ```
 #[cfg(feature = "examples")]
-pub use examples::{compile_example, compile_examples};
+pub fn compile_example<'a>(
+    target_name: &str,
+    args: impl IntoIterator<Item = &'a str>,
+) -> crate::schema::Bin {
+    snapbox::cmd::compile_example(target_name, args).into()
+}
 
+/// Prepare all examples for testing
+///
+/// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
+/// will match the current target and profile but will not get feature flags.  Pass those arguments
+/// to the compiler via `args`.
+///
+/// ## Example
+///
+/// ```rust,no_run
+/// #[test]
+/// fn cli_tests() {
+///     trycmd::TestCases::new()
+///         .register_bins(trycmd::cargo::compile_examples([]).unwrap())
+///         .case("examples/cmd/*.trycmd");
+/// }
+/// ```
 #[cfg(feature = "examples")]
-pub(crate) mod examples {
-    /// Prepare an example for testing
-    ///
-    /// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
-    /// will match the current target and profile but will not get feature flags.  Pass those arguments
-    /// to the compiler via `args`.
-    ///
-    /// ## Example
-    ///
-    /// ```rust,no_run
-    /// #[test]
-    /// fn cli_tests() {
-    ///     trycmd::TestCases::new()
-    ///         .register_bin("example-fixture", trycmd::cargo::compile_example("example-fixture", []))
-    ///         .case("examples/cmd/*.trycmd");
-    /// }
-    /// ```
-    pub fn compile_example<'a>(
-        target_name: &str,
-        args: impl IntoIterator<Item = &'a str>,
-    ) -> crate::schema::Bin {
-        compile_example_path(target_name, args).into()
-    }
-
-    fn compile_example_path<'a>(
-        target_name: &str,
-        args: impl IntoIterator<Item = &'a str>,
-    ) -> Result<crate::schema::Bin, crate::Error> {
-        snapbox::debug!("Compiling example {}", target_name);
-        let messages = escargot::CargoBuild::new()
-            .current_target()
-            .current_release()
-            .example(target_name)
-            .args(args)
-            .exec()
-            .map_err(|e| crate::Error::new(e.to_string()))?;
-        for message in messages {
-            let message = message.map_err(|e| crate::Error::new(e.to_string()))?;
-            let message = message
-                .decode()
-                .map_err(|e| crate::Error::new(e.to_string()))?;
-            snapbox::debug!("Message: {:?}", message);
-            if let Some(bin) = decode_example_message(&message) {
-                let (name, bin) = bin?;
-                assert_eq!(target_name, name);
-                return Ok(bin);
-            }
-        }
-
-        Err(crate::Error::new(format!(
-            "Unknown error building example {}",
-            target_name
-        )))
-    }
-
-    /// Prepare all examples for testing
-    ///
-    /// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
-    /// will match the current target and profile but will not get feature flags.  Pass those arguments
-    /// to the compiler via `args`.
-    ///
-    /// ## Example
-    ///
-    /// ```rust,no_run
-    /// #[test]
-    /// fn cli_tests() {
-    ///     trycmd::TestCases::new()
-    ///         .register_bins(trycmd::cargo::compile_examples([]).unwrap())
-    ///         .case("examples/cmd/*.trycmd");
-    /// }
-    /// ```
-    pub fn compile_examples<'a>(
-        args: impl IntoIterator<Item = &'a str>,
-    ) -> Result<impl Iterator<Item = (String, crate::schema::Bin)>, crate::Error> {
-        snapbox::debug!("Compiling examples");
-        let mut examples = std::collections::BTreeMap::new();
-
-        let messages = escargot::CargoBuild::new()
-            .current_target()
-            .current_release()
-            .examples()
-            .args(args)
-            .exec()
-            .map_err(|e| crate::Error::new(e.to_string()))?;
-        for message in messages {
-            let message = message.map_err(|e| crate::Error::new(e.to_string()))?;
-            let message = message
-                .decode()
-                .map_err(|e| crate::Error::new(e.to_string()))?;
-            snapbox::debug!("Message: {:?}", message);
-            if let Some(bin) = decode_example_message(&message) {
-                let (name, bin) = bin?;
-                examples.insert(name.to_owned(), bin);
-            }
-        }
-
-        Ok(examples.into_iter())
-    }
-
-    fn decode_example_message<'m>(
-        message: &'m escargot::format::Message,
-    ) -> Option<Result<(&'m str, crate::schema::Bin), crate::Error>> {
-        match message {
-            escargot::format::Message::CompilerMessage(msg) => {
-                let level = msg.message.level;
-                if level == escargot::format::diagnostic::DiagnosticLevel::Ice
-                    || level == escargot::format::diagnostic::DiagnosticLevel::Error
-                {
-                    let output = msg
-                        .message
-                        .rendered
-                        .as_deref()
-                        .unwrap_or_else(|| msg.message.message.as_ref())
-                        .to_owned();
-                    if is_example_target(&msg.target) {
-                        let bin = crate::schema::Bin::Error(crate::Error::new(output));
-                        Some(Ok((msg.target.name.as_ref(), bin)))
-                    } else {
-                        Some(Err(crate::Error::new(output)))
-                    }
-                } else {
-                    None
-                }
-            }
-            escargot::format::Message::CompilerArtifact(artifact) => {
-                if !artifact.profile.test && is_example_target(&artifact.target) {
-                    let path = artifact
-                        .executable
-                        .clone()
-                        .expect("cargo is new enough for this to be present");
-                    let bin = crate::schema::Bin::Path(path.into_owned());
-                    Some(Ok((artifact.target.name.as_ref(), bin)))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn is_example_target(target: &escargot::format::Target) -> bool {
-        target.crate_types == ["bin"] && target.kind == ["example"]
-    }
+pub fn compile_examples<'a>(
+    args: impl IntoIterator<Item = &'a str>,
+) -> Result<impl Iterator<Item = (String, crate::schema::Bin)>, crate::Error> {
+    snapbox::cmd::compile_examples(args).map(|i| i.map(|(name, path)| (name, path.into())))
 }


### PR DESCRIPTION
I was pulling `trycmd` into a project just for compiling examples in an easier way.