### PR TITLE
link LICENSE files into snapbox and snapbox-macros crates

### DIFF
--- a/crates/snapbox-macros/LICENSE-APACHE
+++ b/crates/snapbox-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/snapbox-macros/LICENSE-MIT
+++ b/crates/snapbox-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/snapbox/LICENSE-APACHE
+++ b/crates/snapbox/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/snapbox/LICENSE-MIT
+++ b/crates/snapbox/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
The MIT and Apache-2.0 licenses require that redistributed sources
contain a copy of the license text.
