### PR TITLE
Dynamic file loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+- Structs in `trycmd::schema` are now `pub` instead of `pub(crate)`. Their fields are also `pub` instead of `pub(crate)`.
+
 ## [0.14.16] - 2023-04-13
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 
 - Structs in `trycmd::schema` are now `pub` instead of `pub(crate)`. Their fields are also `pub` instead of `pub(crate)`.
+- Custom file loading support.
+  - `TestCases::file_extension_loader()` allows registering a function for loading a file.
+  - You can now define your own file formats or bring modified code for loading `toml` and `trycmd` files.
 
 ## [0.14.16] - 2023-04-13
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -33,6 +33,7 @@ impl Runner {
 
     pub(crate) fn run(
         &self,
+        loaders: &crate::schema::TryCmdLoaders,
         mode: &Mode,
         bins: &crate::BinRegistry,
         substitutions: &snapbox::Substitutions,
@@ -46,7 +47,7 @@ impl Runner {
                 .cases
                 .par_iter()
                 .flat_map(|c| {
-                    let results = c.run(mode, bins, substitutions);
+                    let results = c.run(loaders, mode, bins, substitutions);
 
                     let stderr = stderr();
                     let mut stderr = stderr.lock();
@@ -137,6 +138,7 @@ impl Case {
 
     pub(crate) fn run(
         &self,
+        loaders: &crate::schema::TryCmdLoaders,
         mode: &Mode,
         bins: &crate::BinRegistry,
         substitutions: &snapbox::Substitutions,
@@ -153,7 +155,7 @@ impl Case {
             return vec![Err(output)];
         }
 
-        let mut sequence = match crate::schema::TryCmd::load(&self.path) {
+        let mut sequence = match crate::schema::TryCmd::load(loaders, &self.path) {
             Ok(sequence) => sequence,
             Err(e) => {
                 let output = Output::step(self.path.clone(), "setup".into());

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,10 +6,11 @@ use snapbox::{NormalizeNewlines, NormalizePaths};
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 
+/// Represents an executable set of commands and their environment.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub(crate) struct TryCmd {
-    pub(crate) steps: Vec<Step>,
-    pub(crate) fs: Filesystem,
+pub struct TryCmd {
+    pub steps: Vec<Step>,
+    pub fs: Filesystem,
 }
 
 impl TryCmd {
@@ -576,22 +577,34 @@ impl From<OneShot> for TryCmd {
     }
 }
 
+/// A command invocation and its expected result.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub(crate) struct Step {
-    pub(crate) id: Option<String>,
-    pub(crate) bin: Option<Bin>,
-    pub(crate) args: Vec<String>,
-    pub(crate) env: Env,
-    pub(crate) stdin: Option<crate::Data>,
-    pub(crate) stderr_to_stdout: bool,
-    pub(crate) expected_status_source: Option<usize>,
-    pub(crate) expected_status: Option<CommandStatus>,
-    pub(crate) expected_stdout_source: Option<std::ops::Range<usize>>,
-    pub(crate) expected_stdout: Option<crate::Data>,
-    pub(crate) expected_stderr_source: Option<std::ops::Range<usize>>,
-    pub(crate) expected_stderr: Option<crate::Data>,
-    pub(crate) binary: bool,
-    pub(crate) timeout: Option<std::time::Duration>,
+pub struct Step {
+    /// Uniquely identifies this step from others.
+    pub id: Option<String>,
+    /// The program that will be executed.
+    pub bin: Option<Bin>,
+    /// Arguments to the executed program.
+    pub args: Vec<String>,
+    /// Environment variables for the execution.
+    pub env: Env,
+    /// Process stdin
+    pub stdin: Option<crate::Data>,
+    /// Whether to redirect stderr to stdout.
+    pub stderr_to_stdout: bool,
+    pub expected_status_source: Option<usize>,
+    /// Expected command status result.
+    pub expected_status: Option<CommandStatus>,
+    pub expected_stdout_source: Option<std::ops::Range<usize>>,
+    /// Expected process stdout content.
+    pub expected_stdout: Option<crate::Data>,
+    pub expected_stderr_source: Option<std::ops::Range<usize>>,
+    /// Expected process stderr content.
+    pub expected_stderr: Option<crate::Data>,
+    /// Whether process output is binary (as opposed to text).
+    pub binary: bool,
+    /// How long to wait for process to exit before timing out.
+    pub timeout: Option<std::time::Duration>,
 }
 
 impl Step {
@@ -766,10 +779,12 @@ impl serde::ser::Serialize for JoinedArgs {
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Filesystem {
-    pub(crate) cwd: Option<std::path::PathBuf>,
+    /// Current working directory.
+    pub cwd: Option<std::path::PathBuf>,
     /// Sandbox base
-    pub(crate) base: Option<std::path::PathBuf>,
-    pub(crate) sandbox: Option<bool>,
+    pub base: Option<std::path::PathBuf>,
+    /// Whether to create a sandboxed copy of the base at run-time.
+    pub sandbox: Option<bool>,
 }
 
 impl Filesystem {
@@ -799,15 +814,15 @@ impl Filesystem {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Env {
     #[serde(default)]
-    pub(crate) inherit: Option<bool>,
+    pub inherit: Option<bool>,
     #[serde(default)]
-    pub(crate) add: BTreeMap<String, String>,
+    pub add: BTreeMap<String, String>,
     #[serde(default)]
-    pub(crate) remove: Vec<String>,
+    pub remove: Vec<String>,
 }
 
 impl Env {
-    pub(crate) fn update(&mut self, other: &Self) {
+    pub fn update(&mut self, other: &Self) {
         if self.inherit.is_none() {
             self.inherit = other.inherit;
         }


### PR DESCRIPTION
Thanks for this awesome crate!

Like many other users have reported via GitHub issues, I've run into various limitations where the built-in TOML or `trycmd` file functionality in this crate just isn't powerful enough for my use cases and I'm yearning for missing features.

Adding new features to the test file formats obviously needs to be done with care. It's easy to make bad decisions and be saddled with those mistakes for years. So I understand why many features aren't yet implemented.

This got me thinking: how can I start to experiment with more advanced test file format features without forking this crate or having to reinvent the functionality myself. This PR is my proposed solution.

In a nutshell this PR:

1. Makes `TryCmd`, `Step`, `Filesystem`, and `Env` and all their fields public so `TryCmd` can be instantiated outside of this crate.
2. Adds a public API to `TestCases` that allows providing your own function for loading a file into a `TryCmd`.

Using the new dynamic file loading API, you can define your own extensions / formats or override the built-in ones.

In my opinion this change drastically increases the value of this crate because it enables experimentation with alternative test file formats without having to throw away the test runner. For example, I plan to experiment with modifying the `trycmd` parser to introduce syntax extensions, change semantics around the filesystem sandbox, etc. This type of experimentation is not possible today without a fork since there's no way to customize file loading.