### PR TITLE
fix(snap): Allow multiple values map to a variable

### DIFF
--- a/crates/snapbox/src/substitutions.rs
+++ b/crates/snapbox/src/substitutions.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 /// - `[..]`: match multiple characters within a line
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct Substitutions {
-    vars: std::collections::BTreeMap<&'static str, Cow<'static, str>>,
+    vars: std::collections::BTreeMap<&'static str, std::collections::BTreeSet<Cow<'static, str>>>,
     unused: std::collections::BTreeSet<&'static str>,
 }
 
@@ -43,7 +43,9 @@ impl Substitutions {
             self.unused.insert(key);
         } else {
             self.vars
-                .insert(key, crate::utils::normalize_text(value.as_ref()).into());
+                .entry(key)
+                .or_default()
+                .insert(crate::utils::normalize_text(value.as_ref()).into());
         }
         Ok(())
     }
@@ -79,8 +81,10 @@ impl Substitutions {
     fn substitute<'v>(&self, value: &'v str) -> Cow<'v, str> {
         let mut value = Cow::Borrowed(value);
         for (var, replace) in self.vars.iter() {
-            debug_assert!(!replace.is_empty());
-            value = Cow::Owned(value.replace(replace.as_ref(), var));
+            for replace in replace {
+                debug_assert!(!replace.is_empty());
+                value = Cow::Owned(value.replace(replace.as_ref(), var));
+            }
         }
         value
     }

--- a/crates/snapbox/src/substitutions.rs
+++ b/crates/snapbox/src/substitutions.rs
@@ -63,6 +63,12 @@ impl Substitutions {
         Ok(())
     }
 
+    pub fn remove(&mut self, key: &'static str) -> Result<(), crate::Error> {
+        let key = validate_key(key)?;
+        self.vars.remove(key);
+        Ok(())
+    }
+
     /// Apply match pattern to `input`
     ///
     /// If `pattern` matches `input`, then `pattern` is returned.

--- a/src/cases.rs
+++ b/src/cases.rs
@@ -143,12 +143,20 @@ impl TestCases {
 
     /// Batch add variables for normalizing output
     ///
-    /// See `insert_var`.
+    /// See [`TestCases::insert_var`].
     pub fn extend_vars(
         &self,
         vars: impl IntoIterator<Item = (&'static str, impl Into<Cow<'static, str>>)>,
     ) -> Result<&Self, crate::Error> {
         self.substitutions.borrow_mut().extend(vars)?;
+        Ok(self)
+    }
+
+    /// Remove an existing var values
+    ///
+    /// See [`TestCases::insert_var`].
+    pub fn clear_var(&self, var: &'static str) -> Result<&Self, crate::Error> {
+        self.substitutions.borrow_mut().remove(var)?;
         Ok(self)
     }
 


### PR DESCRIPTION
Solved the overwrite problem by allowing to remove previous entries

This is the snapbox side of #153