### PR TITLE
fix: Respect Assert::normalize_paths when running subset_matches

### DIFF
--- a/crates/snapbox/src/assert.rs
+++ b/crates/snapbox/src/assert.rs
@@ -288,6 +288,7 @@ impl Assert {
             expected_root,
             actual_root,
             &self.substitutions,
+            self.normalize_paths,
         )
         .collect();
         self.verify(checks);


### PR DESCRIPTION
It's probably better to reuse `Assert::normalize_match`, but that requires more API changing. This was just the quickest way for me to get my tests passing 😁 