### PR TITLE
fix(snap): Provide more stable snapshots 

### DIFF
--- a/crates/snapbox/src/data/runtime.rs
+++ b/crates/snapbox/src/data/runtime.rs
@@ -9,7 +9,7 @@ pub(crate) fn get() -> std::sync::MutexGuard<'static, Runtime> {
 
 #[derive(Default)]
 pub(crate) struct Runtime {
-    per_file: Vec<FileRuntime>,
+    per_file: Vec<SourceFileRuntime>,
 }
 
 impl Runtime {
@@ -28,7 +28,7 @@ impl Runtime {
         {
             entry.update(&actual, inline)?;
         } else {
-            let mut entry = FileRuntime::new(inline)?;
+            let mut entry = SourceFileRuntime::new(inline)?;
             entry.update(&actual, inline)?;
             self.per_file.push(entry);
         }
@@ -37,18 +37,18 @@ impl Runtime {
     }
 }
 
-struct FileRuntime {
+struct SourceFileRuntime {
     path: std::path::PathBuf,
     original_text: String,
     patchwork: Patchwork,
 }
 
-impl FileRuntime {
-    fn new(inline: &Inline) -> std::io::Result<FileRuntime> {
+impl SourceFileRuntime {
+    fn new(inline: &Inline) -> std::io::Result<SourceFileRuntime> {
         let path = inline.position.file.clone();
         let original_text = std::fs::read_to_string(&path)?;
         let patchwork = Patchwork::new(original_text.clone());
-        Ok(FileRuntime {
+        Ok(SourceFileRuntime {
             path,
             original_text,
             patchwork,

--- a/crates/snapbox/src/data/runtime.rs
+++ b/crates/snapbox/src/data/runtime.rs
@@ -10,12 +10,29 @@ pub(crate) fn get() -> std::sync::MutexGuard<'static, Runtime> {
 #[derive(Default)]
 pub(crate) struct Runtime {
     per_file: Vec<SourceFileRuntime>,
+    path_count: Vec<PathRuntime>,
 }
 
 impl Runtime {
     const fn new() -> Self {
         Self {
             per_file: Vec::new(),
+            path_count: Vec::new(),
+        }
+    }
+
+    pub(crate) fn count(&mut self, path_prefix: &str) -> usize {
+        if let Some(entry) = self
+            .path_count
+            .iter_mut()
+            .find(|entry| entry.is(path_prefix))
+        {
+            entry.next()
+        } else {
+            let entry = PathRuntime::new(path_prefix);
+            let next = entry.count();
+            self.path_count.push(entry);
+            next
         }
     }
 
@@ -321,6 +338,34 @@ impl StrLitKind {
                 Ok(())
             }
         }
+    }
+}
+
+#[derive(Clone)]
+struct PathRuntime {
+    path_prefix: String,
+    count: usize,
+}
+
+impl PathRuntime {
+    fn new(path_prefix: &str) -> Self {
+        Self {
+            path_prefix: path_prefix.to_owned(),
+            count: 0,
+        }
+    }
+
+    fn is(&self, path_prefix: &str) -> bool {
+        self.path_prefix == path_prefix
+    }
+
+    fn next(&mut self) -> usize {
+        self.count += 1;
+        self.count
+    }
+
+    fn count(&self) -> usize {
+        self.count
     }
 }
 


### PR DESCRIPTION
Before our auto-named snapshots used line numbers to make them unique.
This would fail within macros.
They could easily change for no good reason, requiring deleting the
entire snapshot directory and restarting.

In short, we change
- from `src/<mod>/snapshots/<file>-<line>.txt`
- to `tests/snapshots/<normalized_fn_path>.txt` where `<normalized_fn_path> = <fn_path>.replace("::", "__")`

Our paths were relative to the test file.
I reconsidered this when doing the above because the function name made
things less unique.
In making them unique, I'd need to extend the path a lot
(`src/<path>/snapshots/<path>.txt`).
So I moved them to the root to all be together.

Not considering this a breaking change because of how non-deterministic the file names were before.