### PR TITLE
fix(snap)!: Remove inline snapshot indent support

### DIFF
--- a/crates/snapbox/src/data/mod.rs
+++ b/crates/snapbox/src/data/mod.rs
@@ -85,7 +85,6 @@ macro_rules! str {
         let inline = $crate::data::Inline {
             position,
             data: $data,
-            indent: true,
         };
         inline
     }};

--- a/crates/snapbox/src/data/source.rs
+++ b/crates/snapbox/src/data/source.rs
@@ -75,17 +75,9 @@ pub struct Inline {
     pub position: Position,
     #[doc(hidden)]
     pub data: &'static str,
-    #[doc(hidden)]
-    pub indent: bool,
 }
 
 impl Inline {
-    /// Indent to quote-level when overwriting the string literal (default)
-    pub fn indent(mut self, yes: bool) -> Self {
-        self.indent = yes;
-        self
-    }
-
     /// Initialize `Self` as [`format`][crate::data::DataFormat] or [`Error`][crate::data::DataFormat::Error]
     ///
     /// This is generally used for `expected` data
@@ -103,35 +95,11 @@ impl Inline {
 
     fn trimmed(&self) -> String {
         let mut data = self.data;
-        if data.contains('\n') {
-            if data.starts_with('\n') {
-                data = &data[1..]
-            }
-            if self.indent {
-                return trim_indent(data);
-            }
+        if data.contains('\n') && data.starts_with('\n') {
+            data = &data[1..]
         }
         data.to_owned()
     }
-}
-
-fn trim_indent(text: &str) -> String {
-    let indent = text
-        .lines()
-        .filter(|it| !it.trim().is_empty())
-        .map(|it| it.len() - it.trim_start().len())
-        .min()
-        .unwrap_or(0);
-
-    crate::utils::LinesWithTerminator::new(text)
-        .map(|line| {
-            if line.len() <= indent {
-                line.trim_start_matches(' ')
-            } else {
-                &line[indent..]
-            }
-        })
-        .collect()
 }
 
 impl std::fmt::Display for Inline {

--- a/crates/snapbox/tests/assert.rs
+++ b/crates/snapbox/tests/assert.rs
@@ -11,22 +11,9 @@ fn test_trivial_assert() {
 fn smoke_test_indent() {
     assert_eq(
         str![[r#"
-            line1
-              line2
-        "#]]
-        .indent(true),
-        "\
 line1
   line2
-",
-    );
-
-    assert_eq(
-        str![[r#"
-line1
-  line2
-"#]]
-        .indent(false),
+"#]],
         "\
 line1
   line2


### PR DESCRIPTION
Rather than dealing with the special cases where this doesn't exist, let's just not do this.

This also aligns with the general style within Cargo's tests.

Fixes #267