### PR TITLE
fix(snap)!: Include a trailing newline in snapshots

### DIFF
--- a/crates/snapbox/src/data/runtime.rs
+++ b/crates/snapbox/src/data/runtime.rs
@@ -143,6 +143,9 @@ fn format_patch(patch: &str) -> String {
         buf.push('\n');
     }
     buf.push_str(patch);
+    if is_multiline {
+        buf.push('\n');
+    }
     lit_kind.write_end(&mut buf).unwrap();
     if matches!(lit_kind, StrLitKind::Raw(_)) {
         buf.push(']');
@@ -358,7 +361,9 @@ mod tests {
 [r#"
 hello
 world
-"#]"##]],
+
+"#]
+"##]],
             patch,
         );
 
@@ -394,6 +399,7 @@ Patchwork {
         ),
     ],
 }
+
 "#]],
             patchwork.to_debug(),
         );

--- a/crates/snapbox/src/data/source.rs
+++ b/crates/snapbox/src/data/source.rs
@@ -95,8 +95,9 @@ impl Inline {
 
     fn trimmed(&self) -> String {
         let mut data = self.data;
-        if data.contains('\n') && data.starts_with('\n') {
-            data = &data[1..]
+        if data.contains('\n') {
+            data = data.strip_prefix('\n').unwrap_or(data);
+            data = data.strip_suffix('\n').unwrap_or(data);
         }
         data.to_owned()
     }

--- a/crates/snapbox/tests/assert.rs
+++ b/crates/snapbox/tests/assert.rs
@@ -13,6 +13,7 @@ fn smoke_test_indent() {
         str![[r#"
 line1
   line2
+
 "#]],
         "\
 line1


### PR DESCRIPTION
In using snapshots, I found the leading newline so good that I feel like we should have a trailing newline as well!