### PR TITLE
fix(snap): Change how we normalize matches 

### DIFF
--- a/crates/snapbox/src/substitutions.rs
+++ b/crates/snapbox/src/substitutions.rs
@@ -96,12 +96,12 @@ impl Substitutions {
     }
 
     fn clear<'v>(&self, pattern: &'v str) -> Cow<'v, str> {
-        if pattern.contains('[') {
-            let mut pattern = Cow::Borrowed(pattern);
+        if !self.unused.is_empty() && pattern.contains('[') {
+            let mut pattern = pattern.to_owned();
             for var in self.unused.iter() {
-                pattern = Cow::Owned(pattern.replace(var, ""));
+                pattern = pattern.replace(var, "");
             }
-            pattern
+            Cow::Owned(pattern)
         } else {
             Cow::Borrowed(pattern)
         }

--- a/crates/snapbox/src/substitutions.rs
+++ b/crates/snapbox/src/substitutions.rs
@@ -315,6 +315,15 @@ mod test {
     }
 
     #[test]
+    fn elide_delimited_with_sub() {
+        let input = "Hello World\nHow are you?\nGoodbye World";
+        let pattern = "Hello [..]\n...\nGoodbye [..]";
+        let expected = "Hello [..]\nHow are you?\nGoodbye World";
+        let actual = normalize(input, pattern, &Substitutions::new());
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn leading_elide() {
         let input = "Hello\nWorld\nGoodbye";
         let pattern = "...\nGoodbye";

--- a/crates/snapbox/src/substitutions.rs
+++ b/crates/snapbox/src/substitutions.rs
@@ -84,26 +84,38 @@ impl Substitutions {
         normalize(input, pattern, self)
     }
 
-    fn substitute<'v>(&self, value: &'v str) -> Cow<'v, str> {
-        let mut value = Cow::Borrowed(value);
-        for (var, replace) in self.vars.iter() {
-            for replace in replace {
-                debug_assert!(!replace.is_empty());
-                value = Cow::Owned(value.replace(replace.as_ref(), var));
-            }
-        }
-        value
+    fn substitute(&self, input: &str) -> String {
+        let mut input = input.to_owned();
+        replace_many(
+            &mut input,
+            self.vars.iter().flat_map(|(var, replaces)| {
+                replaces.iter().map(|replace| (*var, replace.as_ref()))
+            }),
+        );
+        input
     }
 
     fn clear<'v>(&self, pattern: &'v str) -> Cow<'v, str> {
         if !self.unused.is_empty() && pattern.contains('[') {
             let mut pattern = pattern.to_owned();
-            for var in self.unused.iter() {
-                pattern = pattern.replace(var, "");
-            }
+            replace_many(&mut pattern, self.unused.iter().map(|var| (*var, "")));
             Cow::Owned(pattern)
         } else {
             Cow::Borrowed(pattern)
+        }
+    }
+}
+
+fn replace_many<'a>(
+    buffer: &mut String,
+    replacements: impl IntoIterator<Item = (&'a str, &'a str)>,
+) {
+    for (var, replace) in replacements {
+        let mut index = 0;
+        while let Some(offset) = buffer[index..].find(var) {
+            let old_range = (index + offset)..(index + offset + var.len());
+            buffer.replace_range(old_range, replace);
+            index += offset + replace.len();
         }
     }
 }


### PR DESCRIPTION
There isn't a succinct way to describe this set of changes.

Know changes:
- You can now end a `...` with a line containing `[..]`
- Variables are always substituted, rather than only when used in the
  pattern
- We don't try as hard to recover from diverging input/pattern