### PR TITLE
chore(deps): Update Rust crate windows-sys to 0.60.1 or earlier

### DIFF
--- a/crates/snapbox/Cargo.toml
+++ b/crates/snapbox/Cargo.toml
@@ -93,7 +93,7 @@ serde = { version = "1.0.198", optional = true }
 regex = { version = "1.10.4", optional = true, default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60.0", features = ["Win32_Foundation"], optional = true }
+windows-sys = { version = ">=0.28, <=0.61", features = ["Win32_Foundation"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.137", optional = true }


### PR DESCRIPTION
windows-sys is a frequent source of duplicate dependencies.  Widening the range of allowed versions gives downstream crates a fighting chance of being able to select one unique version of it.

`cargo test` does pass all tests with both windows-sys 0.61 and 0.28 (and fails to compile on windows-sys 0.27).