### PR TITLE
fix(examples): serialize parallel example compiles

### DIFF
--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -954,11 +954,48 @@ pub use examples::{compile_example, compile_examples};
 
 #[cfg(feature = "examples")]
 pub(crate) mod examples {
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialize `cargo build` invocations so parallel test threads do not deadlock on
+    /// the target directory lock (see snapbox#434).
+    fn compile_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let mutex = LOCK.get_or_init(|| Mutex::new(()));
+        mutex.lock().unwrap_or_else(|err| err.into_inner())
+    }
+
+    /// Ensure `cargo` runs quietly so progress on stderr does not fill the pipe buffer
+    /// while we read JSON messages from stdout (see snapbox#435).
+    fn cargo_build_args<I, S>(args: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let args: Vec<String> = args
+            .into_iter()
+            .map(|arg| arg.as_ref().to_owned())
+            .collect();
+        if args.iter().any(|arg| arg == "-q" || arg == "--quiet") {
+            args
+        } else {
+            let mut with_quiet = Vec::with_capacity(args.len() + 1);
+            with_quiet.push("-q".into());
+            with_quiet.extend(args);
+            with_quiet
+        }
+    }
+
     /// Prepare an example for testing
     ///
     /// Unlike `cargo_bin!`, this does not inherit all of the current compiler settings.  It
     /// will match the current target and profile but will not get feature flags.  Pass those arguments
     /// to the compiler via `args`.
+    ///
+    /// `-q` is passed to `cargo` automatically (unless already present) so progress output on
+    /// stderr does not block the build when reading compiler messages from stdout.
+    ///
+    /// Calls are serialized across threads to avoid target-directory lock contention when
+    /// tests run in parallel. Prefer [`compile_examples`] when registering many examples.
     ///
     /// ## Example
     ///
@@ -970,12 +1007,14 @@ pub(crate) mod examples {
         target_name: &str,
         args: impl IntoIterator<Item = &'a str>,
     ) -> crate::assert::Result<std::path::PathBuf> {
+        let _lock = compile_lock();
         crate::debug!("Compiling example {}", target_name);
+        let args = cargo_build_args(args);
         let messages = escargot::CargoBuild::new()
             .current_target()
             .current_release()
             .example(target_name)
-            .args(args)
+            .args(args.iter().map(|arg| arg.as_str()))
             .exec()
             .map_err(|e| crate::assert::Error::new(e.to_string()))?;
         for message in messages {
@@ -1002,6 +1041,8 @@ pub(crate) mod examples {
     /// will match the current target and profile but will not get feature flags.  Pass those arguments
     /// to the compiler via `args`.
     ///
+    /// `-q` is passed to `cargo` automatically (see [`compile_example`]).
+    ///
     /// ## Example
     ///
     /// ```rust,no_run
@@ -1013,14 +1054,16 @@ pub(crate) mod examples {
     ) -> crate::assert::Result<
         impl Iterator<Item = (String, crate::assert::Result<std::path::PathBuf>)>,
     > {
+        let _lock = compile_lock();
         crate::debug!("Compiling examples");
         let mut examples = std::collections::BTreeMap::new();
 
+        let args = cargo_build_args(args);
         let messages = escargot::CargoBuild::new()
             .current_target()
             .current_release()
             .examples()
-            .args(args)
+            .args(args.iter().map(|arg| arg.as_str()))
             .exec()
             .map_err(|e| crate::assert::Error::new(e.to_string()))?;
         for message in messages {
@@ -1082,6 +1125,21 @@ pub(crate) mod examples {
 
     fn is_example_target(target: &escargot::format::Target<'_>) -> bool {
         target.crate_types == ["bin"] && target.kind == ["example"]
+    }
+
+    #[test]
+    fn cargo_build_args_adds_quiet_by_default() {
+        let args = cargo_build_args::<_, &str>([]);
+        assert_eq!(args, ["-q"]);
+    }
+
+    #[test]
+    fn cargo_build_args_respects_existing_quiet() {
+        let args = cargo_build_args(["-q", "--locked"]);
+        assert_eq!(args, ["-q", "--locked"]);
+
+        let args = cargo_build_args(["--quiet"]);
+        assert_eq!(args, ["--quiet"]);
     }
 }
 


### PR DESCRIPTION
## Summary

Parallel test threads calling `compile_example` each spawn a separate `cargo build --example` subprocess, which can deadlock waiting for an exclusive lock on the target directory.

This holds a process-wide mutex for the duration of each `compile_example` / `compile_examples` invocation so only one example build runs at a time.

Also applies `cargo_build_args` in `compile_example` (was only wired in `compile_examples` after #435).

Fixes #434

## Notes

- Prefer `compile_examples` when registering many examples (single cargo invocation).
- Serialization may slow parallel tests that compile examples individually, but avoids hangs.

## Test plan

- [x] `cargo test -p snapbox --features examples --lib`