### PR TITLE
fix: normalize parent-dir segments in snapshot path display

### DIFF
--- a/crates/snapbox/src/dir/ops.rs
+++ b/crates/snapbox/src/dir/ops.rs
@@ -217,14 +217,15 @@ pub(crate) fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
 }
 
 pub(crate) fn display_relpath(path: impl AsRef<std::path::Path>) -> String {
-    let path = path.as_ref();
+    let path = normalize_path(path.as_ref());
     let relpath = if let Ok(cwd) = std::env::current_dir() {
-        match path.strip_prefix(cwd) {
+        let cwd = normalize_path(&cwd);
+        match path.strip_prefix(&cwd) {
             Ok(path) => path,
-            Err(_) => path,
+            Err(_) => path.as_path(),
         }
     } else {
-        path
+        path.as_path()
     };
     relpath.display().to_string()
 }

--- a/crates/snapbox/src/dir/tests.rs
+++ b/crates/snapbox/src/dir/tests.rs
@@ -1,6 +1,13 @@
 use super::*;
 
 #[test]
+fn display_relpath_normalizes_parent_dir() {
+    let path = std::path::Path::new("tests/integration/../integration/snapshots/out.txt");
+    let rendered = display_relpath(path);
+    assert_eq!(rendered, "tests/integration/snapshots/out.txt");
+}
+
+#[test]
 fn strips_trailing_slash() {
     let path = std::path::Path::new("/foo/bar/");
     let rendered = path.display().to_string();


### PR DESCRIPTION
## Summary

- Normalize `.` / `..` components when rendering snapshot paths in failure output via `display_relpath`.
- Avoids confusing diff headers such as `tests/integration/../integration/snapshots/...` vs a canonical-looking path.
- Uses the existing `normalize_path` helper (no new dependency; does not call `std::fs::canonicalize`, so no UNC/device paths on Windows).

## Test plan

- [x] `cargo test -p snapbox display_relpath_normalizes`
- [x] `cargo test -p snapbox`

Fixes #423