### PR TITLE
fix: resolve current_rs! paths in nested Cargo workspaces

### DIFF
--- a/crates/snapbox/src/macros.rs
+++ b/crates/snapbox/src/macros.rs
@@ -103,12 +103,21 @@ macro_rules! cargo_rustc_current_dir {
         if let Some(rustc_root) = ::std::option_env!("CARGO_RUSTC_CURRENT_DIR") {
             ::std::path::Path::new(rustc_root)
         } else {
-            let manifest_dir = ::std::path::Path::new(::std::env!("CARGO_MANIFEST_DIR"));
-            manifest_dir
-                .ancestors()
-                .filter(|it| it.join("Cargo.toml").exists())
-                .last()
-                .unwrap()
+            let manifest_dir =
+                ::std::path::Path::new(::std::env!("CARGO_MANIFEST_DIR"));
+            let file = ::std::path::Path::new(::std::file!());
+            // Prefer the package manifest dir when `file!` is relative to it (typical
+            // packages and nested workspaces, see https://github.com/assert-rs/snapbox/issues/415).
+            // Fall back to the outermost workspace root when `file!` is relative to that instead.
+            if manifest_dir.join(file).exists() {
+                manifest_dir
+            } else {
+                manifest_dir
+                    .ancestors()
+                    .filter(|it| it.join("Cargo.toml").exists())
+                    .last()
+                    .unwrap()
+            }
         }
     }};
 }
@@ -181,5 +190,27 @@ mod test {
             assert_eq!(fn_path!(), "snapbox::macros::test::nested_fn_path::nested");
         }
         nested();
+    }
+
+    #[test]
+    fn current_rs_points_at_this_file() {
+        let path = crate::current_rs!();
+        assert!(
+            path.exists(),
+            "current_rs!() should resolve to this source file: {path:?}"
+        );
+    }
+
+    #[test]
+    fn package_manifest_joins_file_relative_to_crate() {
+        let manifest =
+            ::std::path::Path::new("/snapbox-bug/sub-ws/foo");
+        let file = ::std::path::Path::new("src/main.rs");
+        let path = manifest.join(file);
+
+        assert_eq!(
+            path,
+            ::std::path::Path::new("/snapbox-bug/sub-ws/foo/src/main.rs")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix `current_rs!()` / `current_dir!()` / `cargo_rustc_current_dir!()` in nested workspace layouts (e.g. a sub-workspace excluded from the root workspace).
- Prefer `CARGO_MANIFEST_DIR` when `file!` resolves relative to the package directory.
- Keep the previous outermost-workspace heuristic as a fallback when `file!` is workspace-relative (snapbox’s own workspace build).

## Test plan

- [x] `cargo test -p snapbox`
- [x] New `current_rs_points_at_this_file` unit test
- [ ] Reproduce with nested workspace from #415 (`snapbox-bug/sub-ws/foo`)

Fixes #415