### PR TITLE
docs(snap): Improve gettting started experience

### DIFF
--- a/crates/snapbox/src/assert/mod.rs
+++ b/crates/snapbox/src/assert/mod.rs
@@ -26,7 +26,9 @@ pub use error::Result;
 /// # use snapbox::Assert;
 /// # use snapbox::file;
 /// let actual = "something";
-/// Assert::new().eq(actual, file!["output.txt"]);
+/// Assert::new()
+///   .action_env("SNAPSHOTS")
+///   .eq(actual, file!["output.txt"]);
 /// ```
 #[derive(Clone, Debug)]
 pub struct Assert {
@@ -62,7 +64,9 @@ impl Assert {
     /// # use snapbox::Assert;
     /// let actual = "something";
     /// let expected = "so[..]g";
-    /// Assert::new().eq(actual, expected);
+    /// Assert::new()
+    ///   .action_env("SNAPSHOTS")
+    ///   .eq(actual, expected);
     /// ```
     ///
     /// Can combine this with [`file!`][crate::file]
@@ -70,7 +74,9 @@ impl Assert {
     /// # use snapbox::Assert;
     /// # use snapbox::file;
     /// let actual = "something";
-    /// Assert::new().eq(actual, file!["output.txt"]);
+    /// Assert::new()
+    ///   .action_env("SNAPSHOTS")
+    ///   .eq(actual, file!["output.txt"]);
     /// ```
     #[track_caller]
     pub fn eq(&self, actual: impl IntoData, expected: impl IntoData) {

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -51,6 +51,8 @@
 //! snapbox::assert_data_eq!(actual, str![["Hello [..] people!"]]);
 //! ```
 //!
+//! To update the snapshot, run the tests with `SNAPSHOTS=overwrite` set.
+//!
 //! # Feature flags
 //!
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -45,9 +45,10 @@
 //!
 //! [`assert_data_eq!`]
 //! ```rust
+//! # use snapbox::str;
 //! let actual = // ...
 //! # "Hello many people!";
-//! snapbox::assert_data_eq!(actual, "Hello [..] people!");
+//! snapbox::assert_data_eq!(actual, str![["Hello [..] people!"]]);
 //! ```
 //!
 //! [`Assert`]

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -45,12 +45,15 @@
 //!
 //! [`assert_data_eq!`]
 //! ```rust
-//! snapbox::assert_data_eq!("Hello many people!", "Hello [..] people!");
+//! let actual = // ...
+//! # "Hello many people!";
+//! snapbox::assert_data_eq!(actual, "Hello [..] people!");
 //! ```
 //!
 //! [`Assert`]
 //! ```rust,no_run
-//! let actual = "...";
+//! let actual = // ...
+//! # "Hello many people!";
 //! snapbox::Assert::new()
 //!     .action_env("SNAPSHOTS")
 //!     .eq(actual, snapbox::file!["help_output_is_clean.txt"]);

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -38,6 +38,10 @@
 //! - [`dir::DirRoot`]: Working directory for tests
 //! - [`Assert`]: Diff a directory against files present in a pattern directory
 //!
+//! Snapshots:
+//! - [`str!`]: In-source snapshots
+//! - [`file!`]: External snapshots
+//!
 //! You can also build your own version of these with the lower-level building blocks these are
 //! made of.
 //!

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -51,15 +51,6 @@
 //! snapbox::assert_data_eq!(actual, str![["Hello [..] people!"]]);
 //! ```
 //!
-//! [`Assert`]
-//! ```rust,no_run
-//! let actual = // ...
-//! # "Hello many people!";
-//! snapbox::Assert::new()
-//!     .action_env("SNAPSHOTS")
-//!     .eq(actual, snapbox::file!["help_output_is_clean.txt"]);
-//! ```
-//!
 //! # Feature flags
 //!
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -41,8 +41,6 @@
 //! You can also build your own version of these with the lower-level building blocks these are
 //! made of.
 //!
-#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
-//!
 //! # Examples
 //!
 //! [`assert_data_eq!`]
@@ -57,6 +55,10 @@
 //!     .action_env("SNAPSHOTS")
 //!     .eq(actual, snapbox::file!["help_output_is_clean.txt"]);
 //! ```
+//!
+//! # Feature flags
+//!
+#![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //!
 //! [trycmd]: https://docs.rs/trycmd
 

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -28,6 +28,9 @@
 //!
 //! Testing Functions:
 //! - [`assert_data_eq!`] for quick and dirty snapshotting
+//!   - [`IntoJson`]: adapt serde types to be asserted against
+//!   - [`std::string::ToString`]: adapt displayable types to be asserted against
+//!   - [`ToDebug`]: adapt `#[derive(Debug)]` types to be asserted against
 //!
 //! Testing Commands:
 //! - [`cmd::Command`]: Process spawning for testing of non-interactive commands


### PR DESCRIPTION
While the output mentions `SNAPSHOTS=overwrite`, people might miss it for various reasons and turn to the docs.

While taking care of that, I found various other improvements to be made.